### PR TITLE
feat: Support FormProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ But you can still check the type definition [here](https://github.com/react-comp
 | fields           | Control Form fields status. Only use when in Redux | [FieldData](#fielddata)[]             | -                |
 | form             | Set form instance created by `useForm`             | [FormInstance](#useform)              | `Form.useForm()` |
 | initialValues    | Initial value of Form                              | Object                                | -                |
+| name             | Config name with [FormProvider](#formprovider)     | string                                | -                |
 | validateMessages | Set validate message template                      | [ValidateMessages](#validatemessages) | -                |
 | onFieldsChange   | Trigger when any value of Field changed            | (changedFields, allFields): void      | -                |
 | onValuesChange   | Trigger when any value of Field changed            | (changedValues, values): void         | -                |
@@ -133,6 +134,13 @@ class Demo extends React.Component {
 | setFieldsValue    | Set fields value                           | (values) => void                                                           |
 | validateFields    | Trigger fields to validate                 | (nameList?: [NamePath](#namepath)[], options?: ValidateOptions) => Promise |
 
+## FormProvider
+
+| Prop             | Description                               | Type                                     | Default |
+| ---------------- | ----------------------------------------- | ---------------------------------------- | ------- |
+| validateMessages | Config global `validateMessages` template | [ValidateMessages](#validatemessages)    | -       |
+| onFormChange     | Trigger by named form fields change       | (name, { changedFields, forms }) => void | -       |
+
 ## Interface
 
 ### NamePath
@@ -177,8 +185,15 @@ class Demo extends React.Component {
 
 ### ValidateMessages
 
-Please ref
+Validate Messages provides a list of error template.
+You can ref [here](https://github.com/react-component/field-form/blob/master/src/utils/messages.ts) for fully default templates.
 
-| Prop     | Type |
-| -------- | ---- |
-| required |      |
+| Prop    | Description         |
+| ------- | ------------------- |
+| enum    | Rule `enum` prop    |
+| len     | Rule `len` prop     |
+| max     | Rule `max` prop     |
+| min     | Rule `min` prop     |
+| name    | Field name          |
+| pattern | Rule `pattern` prop |
+| type    | Rule `type` prop    |

--- a/examples/StateForm-context.tsx
+++ b/examples/StateForm-context.tsx
@@ -1,0 +1,62 @@
+/* eslint-disable react/prop-types */
+
+import React from 'react';
+import StateForm, { FormInstance } from '../src';
+import Input from './components/Input';
+import LabelField from './components/LabelField';
+
+const formStyle: React.CSSProperties = {
+  padding: '10px 15px',
+  flex: 'auto',
+};
+
+const Form1 = () => {
+  const [form] = StateForm.useForm();
+
+  return (
+    <StateForm form={form} style={{ ...formStyle, border: '1px solid #000' }}>
+      <h4>Form 1</h4>
+      <LabelField name="username" rules={[{ required: true }]}>
+        <Input placeholder="password" />
+      </LabelField>
+      <LabelField name="password" rules={[{ required: true }]}>
+        <Input placeholder="password" />
+      </LabelField>
+
+      <button type="submit">Submit</button>
+    </StateForm>
+  );
+};
+
+const Form2 = () => {
+  const [form] = StateForm.useForm();
+
+  return (
+    <StateForm form={form} style={{ ...formStyle, border: '1px solid #F00' }}>
+      <h4>Form 2</h4>
+      <LabelField name="username" rules={[{ required: true }]}>
+        <Input placeholder="password" />
+      </LabelField>
+      <LabelField name="password" rules={[{ required: true }]}>
+        <Input placeholder="password" />
+      </LabelField>
+
+      <button type="submit">Submit</button>
+    </StateForm>
+  );
+};
+
+const Demo = () => {
+  return (
+    <div>
+      <h3>Form Context</h3>
+      <p>Support global `validateMessages` config and communication between forms.</p>
+      <div style={{ display: 'flex', width: '100%' }}>
+        <Form1 />
+        <Form2 />
+      </div>
+    </div>
+  );
+};
+
+export default Demo;

--- a/examples/StateForm-context.tsx
+++ b/examples/StateForm-context.tsx
@@ -23,7 +23,7 @@ const Form1 = () => {
       <h4>Form 1</h4>
       <p>Change me!</p>
       <LabelField name="username" rules={[{ required: true }]}>
-        <Input placeholder="password" />
+        <Input placeholder="username" />
       </LabelField>
       <LabelField name="password" rules={[{ required: true }]}>
         <Input placeholder="password" />
@@ -42,7 +42,7 @@ const Form2 = () => {
       <h4>Form 2</h4>
       <p>Will follow Form 1 but not sync back</p>
       <LabelField name="username" rules={[{ required: true }]}>
-        <Input placeholder="password" />
+        <Input placeholder="username" />
       </LabelField>
       <LabelField name="password" rules={[{ required: true }]}>
         <Input placeholder="password" />
@@ -60,10 +60,10 @@ const Demo = () => {
       <p>Support global `validateMessages` config and communication between forms.</p>
       <FormProvider
         validateMessages={myMessages}
-        onFormChange={(name, forms) => {
-          console.log('change from:', name, forms);
+        onFormChange={(name, { changedFields, forms }) => {
+          console.log('change from:', name, changedFields, forms);
           if (name === 'first') {
-            forms.second.setFieldsValue(forms.first.getFieldsValue());
+            forms.second.setFields(changedFields);
           }
         }}
       >

--- a/examples/StateForm-context.tsx
+++ b/examples/StateForm-context.tsx
@@ -1,9 +1,14 @@
 /* eslint-disable react/prop-types */
 
 import React from 'react';
-import StateForm, { FormInstance } from '../src';
+import StateForm, { FormProvider } from '../src';
 import Input from './components/Input';
 import LabelField from './components/LabelField';
+import { ValidateMessages } from '../src/interface';
+
+const myMessages: ValidateMessages = {
+  required: '${name} 是必需品',
+};
 
 const formStyle: React.CSSProperties = {
   padding: '10px 15px',
@@ -14,8 +19,9 @@ const Form1 = () => {
   const [form] = StateForm.useForm();
 
   return (
-    <StateForm form={form} style={{ ...formStyle, border: '1px solid #000' }}>
+    <StateForm form={form} style={{ ...formStyle, border: '1px solid #000' }} name="first">
       <h4>Form 1</h4>
+      <p>Change me!</p>
       <LabelField name="username" rules={[{ required: true }]}>
         <Input placeholder="password" />
       </LabelField>
@@ -32,8 +38,9 @@ const Form2 = () => {
   const [form] = StateForm.useForm();
 
   return (
-    <StateForm form={form} style={{ ...formStyle, border: '1px solid #F00' }}>
+    <StateForm form={form} style={{ ...formStyle, border: '1px solid #F00' }} name="second">
       <h4>Form 2</h4>
+      <p>Will follow Form 1 but not sync back</p>
       <LabelField name="username" rules={[{ required: true }]}>
         <Input placeholder="password" />
       </LabelField>
@@ -51,10 +58,20 @@ const Demo = () => {
     <div>
       <h3>Form Context</h3>
       <p>Support global `validateMessages` config and communication between forms.</p>
-      <div style={{ display: 'flex', width: '100%' }}>
-        <Form1 />
-        <Form2 />
-      </div>
+      <FormProvider
+        validateMessages={myMessages}
+        onFormChange={(name, forms) => {
+          console.log('change from:', name, forms);
+          if (name === 'first') {
+            forms.second.setFieldsValue(forms.first.getFieldsValue());
+          }
+        }}
+      >
+        <div style={{ display: 'flex', width: '100%' }}>
+          <Form1 />
+          <Form2 />
+        </div>
+      </FormProvider>
     </div>
   );
 };

--- a/examples/components/LabelField.tsx
+++ b/examples/components/LabelField.tsx
@@ -40,7 +40,7 @@ const LabelField: React.FunctionComponent<LabelFieldProps> = ({
             : React.cloneElement(children as React.ReactElement, { ...control });
 
         return (
-          <div>
+          <div style={{ position: 'relative' }}>
             <div style={{ display: 'flex', alignItems: 'center' }}>
               <label style={{ flex: 'none', width: 100 }}>{label || name}</label>
 

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -68,7 +68,7 @@ const StateForm: React.FunctionComponent<StateFormProps> = (
   setCallbacks({
     onValuesChange: (...args) => {
       if (name) {
-        formContext.triggerFormChange(name, formInstance);
+        formContext.triggerFormChange(name);
       }
 
       if (onValuesChange) {

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -1,0 +1,109 @@
+import * as React from 'react';
+import {
+  Store,
+  FormInstance,
+  FieldData,
+  ValidateMessages,
+  Callbacks,
+  InternalFormInstance,
+} from './interface';
+import useForm from './useForm';
+import FieldContext, { HOOK_MARK } from './FieldContext';
+
+type BaseFormProps = Omit<React.FormHTMLAttributes<HTMLFormElement>, 'onSubmit'>;
+
+export interface StateFormProps extends BaseFormProps {
+  initialValues?: Store;
+  form?: FormInstance;
+  children?: (() => JSX.Element | React.ReactNode) | React.ReactNode;
+  fields?: FieldData[];
+  validateMessages?: ValidateMessages;
+  onValuesChange?: Callbacks['onValuesChange'];
+  onFieldsChange?: Callbacks['onFieldsChange'];
+  onFinish?: (values: Store) => void;
+}
+
+const StateForm: React.FunctionComponent<StateFormProps> = (
+  {
+    initialValues,
+    fields,
+    form,
+    children,
+    validateMessages,
+    onValuesChange,
+    onFieldsChange,
+    onFinish,
+    ...restProps
+  }: StateFormProps,
+  ref,
+) => {
+  // We customize handle event since Context will makes all the consumer re-render:
+  // https://reactjs.org/docs/context.html#contextprovider
+  const [formInstance] = useForm(form);
+  const {
+    useSubscribe,
+    setInitialValues,
+    setCallbacks,
+    setValidateMessages,
+  } = (formInstance as InternalFormInstance).getInternalHooks(HOOK_MARK);
+
+  // Pass props to store
+  setValidateMessages(validateMessages);
+  setCallbacks({
+    onValuesChange,
+    onFieldsChange,
+  });
+
+  // Initial store value when first mount
+  const mountRef = React.useRef(null);
+  if (!mountRef.current) {
+    mountRef.current = true;
+    setInitialValues(initialValues);
+  }
+
+  // Prepare children by `children` type
+  let childrenNode = children;
+  const childrenRenderProps = typeof children === 'function';
+  if (childrenRenderProps) {
+    const values = formInstance.getFieldsValue();
+    childrenNode = (children as any)(values, formInstance);
+  }
+  // Not use subscribe when using render props
+  useSubscribe(!childrenRenderProps);
+
+  // Pass ref with form instance
+  React.useImperativeHandle(ref, () => formInstance);
+
+  // Listen if fields provided. We use ref to save prev data here to avoid additional render
+  const prevFieldsRef = React.useRef<FieldData[] | undefined>();
+  if (prevFieldsRef.current !== fields) {
+    formInstance.setFields(fields || []);
+  }
+  prevFieldsRef.current = fields;
+
+  return (
+    <form
+      {...restProps}
+      onSubmit={event => {
+        event.preventDefault();
+        event.stopPropagation();
+
+        formInstance
+          .validateFields()
+          .then(values => {
+            if (onFinish) {
+              onFinish(values);
+            }
+          })
+          // Do nothing about submit catch
+          .catch(e => e);
+      }}
+    >
+      <FieldContext.Provider value={formInstance as InternalFormInstance}>
+        {childrenNode}
+      </FieldContext.Provider>
+    </form>
+  );
+};
+
+export default StateForm;

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -66,16 +66,14 @@ const StateForm: React.FunctionComponent<StateFormProps> = (
     ...validateMessages,
   });
   setCallbacks({
-    onValuesChange: (...args) => {
-      if (name) {
-        formContext.triggerFormChange(name);
-      }
+    onValuesChange,
+    onFieldsChange: (changedFields: FieldData[], ...rest) => {
+      formContext.triggerFormChange(name, changedFields);
 
-      if (onValuesChange) {
-        onValuesChange(...args);
+      if (onFieldsChange) {
+        onFieldsChange(changedFields, ...rest);
       }
     },
-    onFieldsChange,
   });
 
   // Initial store value when first mount

--- a/src/FormContext.ts
+++ b/src/FormContext.ts
@@ -1,8 +1,0 @@
-import * as React from 'react';
-import { ValidateMessages } from './interface';
-
-interface FormContextProps {
-  validateMessages?: ValidateMessages;
-}
-
-const Context = React.createContext<FormContextProps>({});

--- a/src/FormContext.ts
+++ b/src/FormContext.ts
@@ -1,0 +1,8 @@
+import * as React from 'react';
+import { ValidateMessages } from './interface';
+
+interface FormContextProps {
+  validateMessages?: ValidateMessages;
+}
+
+const Context = React.createContext<FormContextProps>({});

--- a/src/FormContext.tsx
+++ b/src/FormContext.tsx
@@ -11,7 +11,7 @@ export interface FormProviderProps {
 }
 
 export interface FormContextProps extends FormProviderProps {
-  triggerFormChange: (name: string, form: FormInstance) => void;
+  triggerFormChange: (name: string) => void;
   registerForm: (name: string, form: FormInstance) => () => void;
 }
 
@@ -38,7 +38,7 @@ const FormProvider: React.FunctionComponent<FormProviderProps> = ({
         // =========================================================
         // =                  Global Form Control                  =
         // =========================================================
-        triggerFormChange: (name, form) => {
+        triggerFormChange: name => {
           if (onFormChange) {
             onFormChange(name, formsRef.current);
           }

--- a/src/FormContext.tsx
+++ b/src/FormContext.tsx
@@ -1,17 +1,22 @@
 import * as React from 'react';
-import { ValidateMessages, FormInstance } from './interface';
+import { ValidateMessages, FormInstance, FieldData } from './interface';
 
 interface Forms {
   [name: string]: FormInstance;
 }
 
+interface FormChangeInfo {
+  changedFields: FieldData[];
+  forms: Forms;
+}
+
 export interface FormProviderProps {
   validateMessages?: ValidateMessages;
-  onFormChange?: (name: string, forms: Forms) => void;
+  onFormChange?: (name: string, info: FormChangeInfo) => void;
 }
 
 export interface FormContextProps extends FormProviderProps {
-  triggerFormChange: (name: string) => void;
+  triggerFormChange: (name: string, changedFields: FieldData[]) => void;
   registerForm: (name: string, form: FormInstance) => () => void;
 }
 
@@ -38,9 +43,12 @@ const FormProvider: React.FunctionComponent<FormProviderProps> = ({
         // =========================================================
         // =                  Global Form Control                  =
         // =========================================================
-        triggerFormChange: name => {
+        triggerFormChange: (name, changedFields) => {
           if (onFormChange) {
-            onFormChange(name, formsRef.current);
+            onFormChange(name, {
+              changedFields,
+              forms: formsRef.current,
+            });
           }
         },
         registerForm: (name, form) => {

--- a/src/FormContext.tsx
+++ b/src/FormContext.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { ValidateMessages, FormInstance } from './interface';
+
+interface Forms {
+  [name: string]: FormInstance;
+}
+
+export interface FormProviderProps {
+  validateMessages?: ValidateMessages;
+  onFormChange?: (name: string, forms: Forms) => void;
+}
+
+export interface FormContextProps extends FormProviderProps {
+  triggerFormChange: (name: string, form: FormInstance) => void;
+  registerForm: (name: string, form: FormInstance) => () => void;
+}
+
+const FormContext = React.createContext<FormContextProps>({
+  triggerFormChange: () => {},
+  registerForm: () => () => {},
+});
+
+const FormProvider: React.FunctionComponent<FormProviderProps> = ({
+  validateMessages,
+  onFormChange,
+  children,
+}) => {
+  const formContext = React.useContext(FormContext);
+
+  const formsRef = React.useRef<Forms>({});
+
+  return (
+    <FormContext.Provider
+      value={{
+        ...formContext,
+        validateMessages,
+
+        // =========================================================
+        // =                  Global Form Control                  =
+        // =========================================================
+        triggerFormChange: (name, form) => {
+          if (onFormChange) {
+            onFormChange(name, formsRef.current);
+          }
+        },
+        registerForm: (name, form) => {
+          if (name) {
+            formsRef.current = {
+              ...formsRef.current,
+              [name]: form,
+            };
+          }
+
+          return () => {
+            const newForms = { ...formsRef.current };
+            delete newForms[name];
+            formsRef.current = newForms;
+          };
+        },
+      }}
+    >
+      {children}
+    </FormContext.Provider>
+  );
+};
+
+export { FormProvider };
+
+export default FormContext;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,114 +1,11 @@
 import * as React from 'react';
-import {
-  Callbacks,
-  FieldData,
-  FormInstance,
-  Store,
-  ValidateMessages,
-  InternalFormInstance,
-} from './interface';
-import FieldContext, { HOOK_MARK } from './FieldContext';
+import { FormInstance } from './interface';
 import Field from './Field';
 import List from './List';
 import useForm from './useForm';
+import FieldForm, { StateFormProps } from './Form';
 
-type BaseFormProps = Omit<React.FormHTMLAttributes<HTMLFormElement>, 'onSubmit'>;
-
-export interface StateFormProps extends BaseFormProps {
-  initialValues?: Store;
-  form?: FormInstance;
-  children?: (() => JSX.Element | React.ReactNode) | React.ReactNode;
-  fields?: FieldData[];
-  validateMessages?: ValidateMessages;
-  onValuesChange?: Callbacks['onValuesChange'];
-  onFieldsChange?: Callbacks['onFieldsChange'];
-  onFinish?: (values: Store) => void;
-}
-
-const StateForm: React.FunctionComponent<StateFormProps> = (
-  {
-    initialValues,
-    fields,
-    form,
-    children,
-    validateMessages,
-    onValuesChange,
-    onFieldsChange,
-    onFinish,
-    ...restProps
-  }: StateFormProps,
-  ref,
-) => {
-  // We customize handle event since Context will makes all the consumer re-render:
-  // https://reactjs.org/docs/context.html#contextprovider
-  const [formInstance] = useForm(form);
-  const {
-    useSubscribe,
-    setInitialValues,
-    setCallbacks,
-    setValidateMessages,
-  } = (formInstance as InternalFormInstance).getInternalHooks(HOOK_MARK);
-
-  // Pass props to store
-  setValidateMessages(validateMessages);
-  setCallbacks({
-    onValuesChange,
-    onFieldsChange,
-  });
-
-  // Initial store value when first mount
-  const mountRef = React.useRef(null);
-  if (!mountRef.current) {
-    mountRef.current = true;
-    setInitialValues(initialValues);
-  }
-
-  // Prepare children by `children` type
-  let childrenNode = children;
-  const childrenRenderProps = typeof children === 'function';
-  if (childrenRenderProps) {
-    const values = formInstance.getFieldsValue();
-    childrenNode = (children as any)(values, formInstance);
-  }
-  // Not use subscribe when using render props
-  useSubscribe(!childrenRenderProps);
-
-  // Pass ref with form instance
-  React.useImperativeHandle(ref, () => formInstance);
-
-  // Listen if fields provided. We use ref to save prev data here to avoid additional render
-  const prevFieldsRef = React.useRef<FieldData[] | undefined>();
-  if (prevFieldsRef.current !== fields) {
-    formInstance.setFields(fields || []);
-  }
-  prevFieldsRef.current = fields;
-
-  return (
-    <form
-      {...restProps}
-      onSubmit={event => {
-        event.preventDefault();
-        event.stopPropagation();
-
-        formInstance
-          .validateFields()
-          .then(values => {
-            if (onFinish) {
-              onFinish(values);
-            }
-          })
-          // Do nothing about submit catch
-          .catch(e => e);
-      }}
-    >
-      <FieldContext.Provider value={formInstance as InternalFormInstance}>
-        {childrenNode}
-      </FieldContext.Provider>
-    </form>
-  );
-};
-
-const InternalStateForm = React.forwardRef<FormInstance, StateFormProps>(StateForm);
+const InternalStateForm = React.forwardRef<FormInstance, StateFormProps>(FieldForm);
 
 type InternalStateForm = typeof InternalStateForm;
 interface RefStateForm extends InternalStateForm {
@@ -123,6 +20,6 @@ RefStateForm.Field = Field;
 RefStateForm.List = List;
 RefStateForm.useForm = useForm;
 
-export { FormInstance, Field };
+export { FormInstance, Field, useForm };
 
 export default RefStateForm;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,11 +4,13 @@ import Field from './Field';
 import List from './List';
 import useForm from './useForm';
 import FieldForm, { StateFormProps } from './Form';
+import { FormProvider } from './FormContext';
 
 const InternalStateForm = React.forwardRef<FormInstance, StateFormProps>(FieldForm);
 
 type InternalStateForm = typeof InternalStateForm;
 interface RefStateForm extends InternalStateForm {
+  FormProvider: typeof FormProvider;
   Field: typeof Field;
   List: typeof List;
   useForm: typeof useForm;
@@ -16,10 +18,11 @@ interface RefStateForm extends InternalStateForm {
 
 const RefStateForm: RefStateForm = InternalStateForm as any;
 
+RefStateForm.FormProvider = FormProvider;
 RefStateForm.Field = Field;
 RefStateForm.List = List;
 RefStateForm.useForm = useForm;
 
-export { FormInstance, Field, useForm };
+export { FormInstance, Field, useForm, FormProvider };
 
 export default RefStateForm;

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -9,7 +9,6 @@ import {
   NamePath,
   NotifyInfo,
   Store,
-  ValidateFields,
   ValidateOptions,
   FormInstance,
   ValidateMessages,

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -238,7 +238,7 @@ export class FormStore {
     let fields: FieldData[];
 
     if (!namePathList) {
-      this.getFieldEntities(true).map(
+      fields = this.getFieldEntities(true).map(
         (field: FieldEntity): FieldData => {
           const namePath = field.getNamePath();
           const meta = field.getMeta();


### PR DESCRIPTION
* Support global `validateMessages` config.
* Support communication between forms.

#### Preview

📸 [Context Demo](https://rc-field-form-git-context.react-component.now.sh/?selectedKind=rc-field-form&selectedStory=StateForm-context&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel)

#### Document

📖 https://github.com/react-component/field-form/blob/context/README.md#formprovider