### PR TITLE
feat: `dependencies` support trigger child Field update

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ We use typescript to create the Type definition. You can view directly in IDE. B
 
 | Prop | Description | Type | Default |
 | --- | --- | --- | --- |
-| name | Field name path | [NamePath](#namepath)[] | - |
+| dependencies | Will re-render if dependencies changed | [NamePath](#namepath)[] | - |
+| name | Field name path | [NamePath](#namepath) | - |
 | rules | Validate rules | [Rule](#rule)[] | - |
 | shouldUpdate | Check if Field should update | (prevValues, nextValues): boolean | - |
 | trigger | Collect value update by event trigger | string | onChange |

--- a/examples/StateForm-basic.tsx
+++ b/examples/StateForm-basic.tsx
@@ -35,7 +35,7 @@ export default class Demo extends React.Component {
           </Field>
 
           <h4>Show additional field when `username` is `111`</h4>
-          <Field shouldUpdate={(prev, next) => prev.username !== next.username}>
+          <Field dependencies={['username']}>
             {(control, meta, context) => {
               const { username } = context.getFieldsValue();
               return username === '111' ? <Input {...control} placeholder="I am secret!" /> : null;

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@types/react": "^16.8.19",
     "@types/react-dom": "^16.8.4",
+    "@types/warning": "^3.0.0",
     "enzyme": "^3.1.0",
     "enzyme-adapter-react-16": "^1.0.2",
     "enzyme-to-json": "^3.1.4",
@@ -50,7 +51,6 @@
     "react-dom": "^16.8.6",
     "react-redux": "^4.4.10",
     "react-router": "^3.0.0",
-    "react-test-renderer": "^16.1.1",
     "redux": "^3.7.2"
   },
   "pre-commit": [
@@ -58,7 +58,6 @@
   ],
   "dependencies": {
     "async-validator": "^1.11.2",
-    "babel-runtime": "6.x",
     "lodash": "^4.17.4",
     "rc-util": "^4.6.0",
     "warning": "^4.0.3"

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -324,7 +324,7 @@ export class FormStore {
       onValuesChange(changedValues, this.store);
     }
 
-    this.triggerOnFieldsChange([namePath]);
+    this.triggerOnFieldsChange([namePath, ...childrenFields]);
   };
 
   // Let all child Field get update.
@@ -365,8 +365,8 @@ export class FormStore {
         if (!children.has(field)) {
           children.add(field);
 
-          if (field.isFieldTouched()) {
-            const fieldNamePath = field.getNamePath();
+          const fieldNamePath = field.getNamePath();
+          if (field.isFieldTouched() && fieldNamePath.length) {
             childrenFields.push(fieldNamePath);
             fillChildren(fieldNamePath);
           }

--- a/tests/common/index.js
+++ b/tests/common/index.js
@@ -1,4 +1,5 @@
 import timeout from './timeout';
+import InfoField from './InfoField';
 
 export async function changeValue(wrapper, value) {
   wrapper.find('input').simulate('change', { target: { value } });
@@ -16,4 +17,8 @@ export function matchError(wrapper, error) {
   if (error && typeof error !== 'boolean') {
     expect(wrapper.find('.errors li').text()).toBe(error);
   }
+}
+
+export function getField(wrapper, index = 0) {
+  return wrapper.find(InfoField).at(index);
 }

--- a/tests/dependencies.test.js
+++ b/tests/dependencies.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import Form from '../src';
+import InfoField from './common/InfoField';
+import { changeValue, matchError, getField } from './common';
+
+describe('dependencies', () => {
+  it('touched', async () => {
+    let form = null;
+
+    const wrapper = mount(
+      <div>
+        <Form
+          ref={instance => {
+            form = instance;
+          }}
+        >
+          <InfoField name="field_1" />
+          <InfoField name="field_2" rules={[{ required: true }]} dependencies={['field_1']} />
+        </Form>
+      </div>,
+    );
+
+    // Not trigger if not touched
+    await changeValue(getField(wrapper, 0), '');
+    matchError(getField(wrapper, 1), false);
+
+    // Trigger if touched
+    form.setFields([{ name: 'field_2', touched: true }]);
+    await changeValue(getField(wrapper, 0), '');
+    matchError(getField(wrapper, 1), true);
+  });
+});


### PR DESCRIPTION
Simplify render logic:
```jsx
<Form>
  <Field name="field_1">
    <input />
  </Field>
  <Field dependencies={['field_1']}>
    {(_, _, { getFieldValue }) => (
      getFieldValue('field_1') === 'aaa' &&
      <Field name="field_1">
        <input />
      </Field>
    )}
  </Field>
</Form>
```