### PR TITLE
feat(useForm): add method setFieldsValueByPath to support 'a.b.c' for…

### DIFF
--- a/examples/setFieldsValueByPath.tsx
+++ b/examples/setFieldsValueByPath.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import Form, { Field, FormInstance } from '../src';
+import Input from './components/Input';
+
+export default class Demo extends React.Component {
+  public state = {};
+
+  public form: FormInstance;
+
+  setFieldsValueByPath = () => {
+    const fieldsValue = {
+      [['children', 1, 'level'].join('.')]: 'High',
+    };
+    this.form.setFieldsValueByPath(fieldsValue);
+  };
+
+  public render() {
+    return (
+      <div>
+        <Form
+          ref={inst => {
+            this.form = inst;
+          }}
+          initialValues={{
+            children: [{ language: 'java' }],
+          }}
+        >
+          <Field name={['children', 0, 'language']}>
+            <Input placeholder="input language" />
+          </Field>
+          <Field name={['children', 1, 'level']}>
+            <Input placeholder="input level" />
+          </Field>
+        </Form>
+        <br />
+        <button type="button" onClick={this.setFieldsValueByPath}>
+          setFieldsValueByPath
+        </button>
+      </div>
+    );
+  }
+}

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -166,6 +166,7 @@ export interface FormInstance {
   resetFields: (fields?: NamePath[]) => void;
   setFields: (fields: FieldData[]) => void;
   setFieldsValue: (value: Store) => void;
+  setFieldsValueByPath: (value: Store) => void;
   validateFields: ValidateFields;
 
   // New API

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -29,6 +29,7 @@ import {
   getValue,
   setValue,
   setValues,
+  setValuesByPath,
 } from './utils/valueUtil';
 
 interface UpdateAction {
@@ -78,6 +79,7 @@ export class FormStore {
     resetFields: this.resetFields,
     setFields: this.setFields,
     setFieldsValue: this.setFieldsValue,
+    setFieldsValueByPath: this.setFieldsValueByPath,
     validateFields: this.validateFields,
     submit: this.submit,
 
@@ -368,6 +370,19 @@ export class FormStore {
 
     if (store) {
       this.store = setValues(this.store, store);
+    }
+
+    this.notifyObservers(prevStore, null, { type: 'valueUpdate', source: 'external' });
+  };
+
+  /**
+   * support `{'a.b.c': 1}` format.
+   */
+  private setFieldsValueByPath = (store: Store) => {
+    const prevStore = this.store;
+
+    if (store) {
+      this.store = setValuesByPath(this.store, store);
     }
 
     this.notifyObservers(prevStore, null, { type: 'valueUpdate', source: 'external' });

--- a/src/utils/valueUtil.ts
+++ b/src/utils/valueUtil.ts
@@ -72,6 +72,12 @@ export function setValues<T>(store: T, ...restValues: T[]): T {
   );
 }
 
+export function setValuesByPath(store: Store, values: Store): Store {
+  return Object.keys(values).reduce(
+    (current: Store, path: string): Store => setIn(path, values[path], current),
+    store,
+  );
+}
 export function matchNamePath(
   namePath: InternalNamePath,
   changedNamePath: InternalNamePath | null,

--- a/tests/legacy/basic-form.test.js
+++ b/tests/legacy/basic-form.test.js
@@ -125,5 +125,34 @@ describe('legacy.basic-form', () => {
       form.setFieldsValue({ user: { name: 'Light' } });
       expect(onValuesChange).not.toHaveBeenCalled();
     });
+
+    it('**Not** trigger `onValuesChange` when `setFieldsValueByPath`', () => {
+      let form;
+      const onValuesChange = jest.fn();
+
+      mount(
+        <div>
+          <Form
+            ref={instance => {
+              form = instance;
+            }}
+            onValuesChange={onValuesChange}
+          >
+            <Field name={['user', 'name']}>
+              <Input />
+            </Field>
+            <Field name={['user', 'age']}>
+              <Input type="number" />
+            </Field>
+            <Field name="agreement">
+              <Input type="checkbox" />
+            </Field>
+          </Form>
+        </div>,
+      );
+
+      form.setFieldsValueByPath({ 'user.name': 'Light' });
+      expect(onValuesChange).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/legacy/form.test.js
+++ b/tests/legacy/form.test.js
@@ -20,6 +20,12 @@ describe('legacy.form', () => {
           <Field name="normal">
             <Input />
           </Field>
+          <Field name={['children', 0, 'level']}>
+            <Input />
+          </Field>
+          <Field name={['children', 1, 'level']}>
+            <Input />
+          </Field>
         </Form>
       </div>,
     );
@@ -27,9 +33,16 @@ describe('legacy.form', () => {
     form.setFieldsValue({
       normal: '2',
       notExist: 'oh',
+      children: [{ level: 'Medium' }],
     });
 
     expect(form.getFieldValue('normal')).toBe('2');
+    expect(form.getFieldValue(['children', 0, 'level'])).toBe('Medium');
+
+    form.setFieldsValueByPath({
+      'children[1].level': 'High',
+    });
+    expect(form.getFieldValue(['children', 1, 'level'])).toBe('High');
   });
 
   // [Legacy] Seems useless

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,4 +1,4 @@
-import { move, isSimilar, setValues } from '../src/utils/valueUtil';
+import { move, isSimilar, setValues, setValuesByPath } from '../src/utils/valueUtil';
 import NameMap from '../src/utils/NameMap';
 
 describe('utils', () => {
@@ -34,6 +34,16 @@ describe('utils', () => {
     it('setValues', () => {
       expect(setValues({}, { a: 1 }, { b: 2 })).toEqual({ a: 1, b: 2 });
       expect(setValues([], [123])).toEqual([123]);
+    });
+
+    it('setValuesByPath', () => {
+      const store = { children: [{ a: 1 }, { b: 2 }] };
+      const newStore = { children: [{ a: 1 }, { b: 3 }] };
+      expect(setValuesByPath(store, { 'children.1.b': 3 })).toEqual(newStore);
+      expect(store.children[1].b).toBe(2);
+      expect(newStore.children[1].b).toBe(3);
+      expect(newStore.children[0]).not.toBe(store.children[0]);
+      expect(newStore.children[0]).toEqual(store.children[0]);
     });
   });
 


### PR DESCRIPTION
To solve the problem #32 , support setFieldsValue with format `{'a.children[1].c': 'High'}`.
so I think to add new instance method `setFieldsValueByPath`.