### PR TITLE
Move all interfaces to interface.ts for refactoring

### DIFF
--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -6,7 +6,6 @@ import {
   FormInstance,
   InternalNamePath,
   Meta,
-  NamePath,
   NotifyInfo,
   Rule,
   Store,
@@ -15,6 +14,9 @@ import {
   RuleObject,
   StoreValue,
   EventArgs,
+  FieldState,
+  FieldProps,
+  ChildProps,
 } from './interface';
 import FieldContext, { HOOK_MARK } from './FieldContext';
 import { toArray } from './utils/typeUtil';
@@ -25,50 +27,6 @@ import {
   getNamePath,
   getValue,
 } from './utils/valueUtil';
-
-interface ChildProps {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [name: string]: any;
-}
-
-export interface FieldProps {
-  children?:
-    | React.ReactElement
-    | ((
-        control: ChildProps,
-        meta: Meta,
-        form: FormInstance,
-      ) => React.ReactNode);
-  /**
-   * Set up `dependencies` field.
-   * When dependencies field update and current field is touched,
-   * will trigger validate rules and render.
-   */
-  dependencies?: NamePath[];
-  getValueFromEvent?: (...args: EventArgs) => StoreValue;
-  name?: NamePath;
-  normalize?: (
-    value: StoreValue,
-    prevValue: StoreValue,
-    allValues: Store,
-  ) => StoreValue;
-  rules?: Rule[];
-  shouldUpdate?:
-    | true
-    | ((
-        prevValues: Store,
-        nextValues: Store,
-        info: { source?: string },
-      ) => boolean);
-  trigger?: string;
-  validateTrigger?: string | string[] | false;
-  valuePropName?: string;
-  onReset?: () => void;
-}
-
-export interface FieldState {
-  reset: boolean;
-}
 
 // We use Class instead of Hooks here since it will cost much code by using Hooks.
 class Field extends React.Component<FieldProps, FieldState>

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -1,35 +1,16 @@
 import * as React from 'react';
 import {
   Store,
-  FormInstance,
   FieldData,
-  ValidateMessages,
-  Callbacks,
   InternalFormInstance,
+  RenderProps,
+  FormProps,
+  FormContextProps,
 } from './interface';
 import useForm from './useForm';
 import FieldContext, { HOOK_MARK } from './FieldContext';
-import FormContext, { FormContextProps } from './FormContext';
+import FormContext from './FormContext';
 import { isSimilar } from './utils/valueUtil';
-
-type BaseFormProps = Omit<React.FormHTMLAttributes<HTMLFormElement>, 'onSubmit'>;
-
-type RenderProps = (values: Store, form: FormInstance) => JSX.Element | React.ReactNode;
-
-export interface FormProps extends BaseFormProps {
-  initialValues?: Store;
-  form?: FormInstance;
-  children?: RenderProps | React.ReactNode;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  component?: false | string | React.FC<any> | React.ComponentClass<any>;
-  fields?: FieldData[];
-  name?: string;
-  validateMessages?: ValidateMessages;
-  onValuesChange?: Callbacks['onValuesChange'];
-  onFieldsChange?: Callbacks['onFieldsChange'];
-  onFinish?: Callbacks['onFinish'];
-  onFinishFailed?: Callbacks['onFinishFailed'];
-}
 
 const Form: React.FunctionComponent<FormProps> = (
   {

--- a/src/FormContext.tsx
+++ b/src/FormContext.tsx
@@ -1,32 +1,5 @@
 import * as React from 'react';
-import { ValidateMessages, FormInstance, FieldData, Store } from './interface';
-
-interface Forms {
-  [name: string]: FormInstance;
-}
-
-interface FormChangeInfo {
-  changedFields: FieldData[];
-  forms: Forms;
-}
-
-interface FormFinishInfo {
-  values: Store;
-  forms: Forms;
-}
-
-export interface FormProviderProps {
-  validateMessages?: ValidateMessages;
-  onFormChange?: (name: string, info: FormChangeInfo) => void;
-  onFormFinish?: (name: string, info: FormFinishInfo) => void;
-}
-
-export interface FormContextProps extends FormProviderProps {
-  triggerFormChange: (name: string, changedFields: FieldData[]) => void;
-  triggerFormFinish: (name: string, values: Store) => void;
-  registerForm: (name: string, form: FormInstance) => void;
-  unregisterForm: (name: string) => void;
-}
+import { FormContextProps, FormProviderProps, Forms } from './interface';
 
 const FormContext = React.createContext<FormContextProps>({
   triggerFormChange: () => {},
@@ -49,7 +22,10 @@ const FormProvider: React.FunctionComponent<FormProviderProps> = ({
     <FormContext.Provider
       value={{
         ...formContext,
-        validateMessages: { ...formContext.validateMessages, ...validateMessages },
+        validateMessages: {
+          ...formContext.validateMessages,
+          ...validateMessages,
+        },
 
         // =========================================================
         // =                  Global Form Control                  =

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -1,25 +1,15 @@
 import * as React from 'react';
 import warning from 'warning';
-import { InternalNamePath, NamePath, StoreValue } from './interface';
+import {
+  InternalNamePath,
+  StoreValue,
+  ListField,
+  ListOperations,
+  ListProps,
+} from './interface';
 import FieldContext from './FieldContext';
 import Field from './Field';
 import { move, getNamePath } from './utils/valueUtil';
-
-interface ListField {
-  name: number;
-  key: number;
-}
-
-interface ListOperations {
-  add: () => void;
-  remove: (index: number) => void;
-  move: (from: number, to: number) => void;
-}
-
-interface ListProps {
-  name: NamePath;
-  children?: (fields: ListField[], operations: ListOperations) => JSX.Element | React.ReactNode;
-}
 
 const List: React.FunctionComponent<ListProps> = ({ name, children }) => {
   const context = React.useContext(FieldContext);
@@ -36,9 +26,16 @@ const List: React.FunctionComponent<ListProps> = ({ name, children }) => {
   }
 
   const parentPrefixName = getNamePath(context.prefixName) || [];
-  const prefixName: InternalNamePath = [...parentPrefixName, ...getNamePath(name)];
+  const prefixName: InternalNamePath = [
+    ...parentPrefixName,
+    ...getNamePath(name),
+  ];
 
-  const shouldUpdate = (prevValue: StoreValue, nextValue: StoreValue, { source }) => {
+  const shouldUpdate = (
+    prevValue: StoreValue,
+    nextValue: StoreValue,
+    { source },
+  ) => {
     if (source === 'internal') {
       return false;
     }
@@ -93,7 +90,12 @@ const List: React.FunctionComponent<ListProps> = ({ name, children }) => {
               const newValue = getNewValue();
 
               // Do not handle out of range
-              if (from < 0 || from >= newValue.length || to < 0 || to >= newValue.length) {
+              if (
+                from < 0 ||
+                from >= newValue.length ||
+                to < 0 ||
+                to >= newValue.length
+              ) {
                 return;
               }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { FormInstance } from './interface';
+import { FormInstance, FormProps } from './interface';
 import Field from './Field';
 import List from './List';
 import useForm from './useForm';
-import FieldForm, { FormProps } from './Form';
+import FieldForm from './Form';
 import { FormProvider } from './FormContext';
 
 const InternalForm = React.forwardRef<FormInstance, FormProps>(FieldForm);

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -4,9 +4,124 @@ import { ReducerAction } from './useForm';
 export type InternalNamePath = (string | number)[];
 export type NamePath = string | number | InternalNamePath;
 
+export type BaseFormProps = Omit<
+  React.FormHTMLAttributes<HTMLFormElement>,
+  'onSubmit'
+>;
+
+export type RenderProps = (
+  values: Store,
+  form: FormInstance,
+) => JSX.Element | React.ReactNode;
+
+export interface FormProps extends BaseFormProps {
+  initialValues?: Store;
+  form?: FormInstance;
+  children?: RenderProps | React.ReactNode;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  component?: false | string | React.FC<any> | React.ComponentClass<any>;
+  fields?: FieldData[];
+  name?: string;
+  validateMessages?: ValidateMessages;
+  onValuesChange?: Callbacks['onValuesChange'];
+  onFieldsChange?: Callbacks['onFieldsChange'];
+  onFinish?: Callbacks['onFinish'];
+  onFinishFailed?: Callbacks['onFinishFailed'];
+}
+
 export type StoreValue = any;
 export interface Store {
   [name: string]: StoreValue;
+}
+
+export interface Forms {
+  [name: string]: FormInstance;
+}
+
+export interface FormChangeInfo {
+  changedFields: FieldData[];
+  forms: Forms;
+}
+
+export interface FormFinishInfo {
+  values: Store;
+  forms: Forms;
+}
+
+export interface FormProviderProps {
+  validateMessages?: ValidateMessages;
+  onFormChange?: (name: string, info: FormChangeInfo) => void;
+  onFormFinish?: (name: string, info: FormFinishInfo) => void;
+}
+
+export interface FormContextProps extends FormProviderProps {
+  triggerFormChange: (name: string, changedFields: FieldData[]) => void;
+  triggerFormFinish: (name: string, values: Store) => void;
+  registerForm: (name: string, form: FormInstance) => void;
+  unregisterForm: (name: string) => void;
+}
+
+export interface ListField {
+  name: number;
+  key: number;
+}
+
+export interface ListOperations {
+  add: () => void;
+  remove: (index: number) => void;
+  move: (from: number, to: number) => void;
+}
+
+export interface ListProps {
+  name: NamePath;
+  children?: (
+    fields: ListField[],
+    operations: ListOperations,
+  ) => JSX.Element | React.ReactNode;
+}
+
+export interface ChildProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [name: string]: any;
+}
+
+export interface FieldProps {
+  children?:
+    | React.ReactElement
+    | ((
+        control: ChildProps,
+        meta: Meta,
+        form: FormInstance,
+      ) => React.ReactNode);
+  /**
+   * Set up `dependencies` field.
+   * When dependencies field update and current field is touched,
+   * will trigger validate rules and render.
+   */
+  dependencies?: NamePath[];
+  getValueFromEvent?: (...args: EventArgs) => StoreValue;
+  name?: NamePath;
+  normalize?: (
+    value: StoreValue,
+    prevValue: StoreValue,
+    allValues: Store,
+  ) => StoreValue;
+  rules?: Rule[];
+  shouldUpdate?:
+    | true
+    | ((
+        prevValues: Store,
+        nextValues: Store,
+        info: { source?: string },
+      ) => boolean);
+  trigger?: string;
+  validateTrigger?: string | string[] | false;
+  valuePropName?: string;
+  onReset?: () => void;
+}
+
+export interface FieldState {
+  reset: boolean;
 }
 
 export interface Meta {
@@ -80,7 +195,11 @@ export interface ValidateErrorEntity {
 }
 
 export interface FieldEntity {
-  onStoreChange: (store: Store, namePathList: InternalNamePath[] | null, info: NotifyInfo) => void;
+  onStoreChange: (
+    store: Store,
+    namePathList: InternalNamePath[] | null,
+    info: NotifyInfo,
+  ) => void;
   isFieldTouched: () => boolean;
   isFieldValidating: () => boolean;
   validateRules: (options?: ValidateOptions) => Promise<string[]>;


### PR DESCRIPTION
I move all the interfaces to interface.ts for refactoring.

This code I committed is the fully refactored code so if the current test code passes through, I think there is no need for more test codes.
If I'm wrong, please leave a comment below.
