### PR TITLE
Fix type error in Field.d.ts (fixes #67)

### DIFF
--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -164,11 +164,7 @@ class Field extends React.Component<FieldProps, FieldState> implements FieldEnti
 
   // ========================= Field Entity Interfaces =========================
   // Trigger by store update. Check if need update the component
-  public onStoreChange = (
-    prevStore: Store,
-    namePathList: InternalNamePath[] | null,
-    info: NotifyInfo,
-  ) => {
+  public onStoreChange: FieldEntity['onStoreChange'] = (prevStore, namePathList, info) => {
     const { shouldUpdate, dependencies = [], onReset } = this.props;
     const { getFieldsValue }: FormInstance = this.context;
     const values = getFieldsValue(true);


### PR DESCRIPTION
I believe this should resolve the type error in the build output in `Field.d.ts`. The `Field` class implements the `FieldEntity` interface, but the generated type for the class differs from the interface resulting in this type error:
```
Property 'onStoreChange' in type 'Field' is not assignable to the same property in base type 'FieldEntity'.
  Type '(prevStore: Store, namePathList: InternalNamePath[], info: NotifyInfo) => void' is not assignable to type '(store: Store, namePathList: InternalNamePath[] | null, info: NotifyInfo) => void'.
    Types of parameters 'namePathList' and 'namePathList' are incompatible.
      Type 'InternalNamePath[] | null' is not assignable to type 'InternalNamePath[]'.
        Type 'null' is not assignable to type 'InternalNamePath[]'
```
I'm not entirely sure why the existing code is causing problems, but I believe this will fix it.