### PR TITLE
improve: onFinish and submit Promise

### DIFF
--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -85,11 +85,12 @@ const Form: React.ForwardRefRenderFunction<FormInstance, FormProps> = (
         onFieldsChange(changedFields, ...rest);
       }
     },
+    // eslint-disable-next-line consistent-return
     onFinish: (values: Store) => {
       formContext.triggerFormFinish(name, values);
 
       if (onFinish) {
-        onFinish(values);
+        return onFinish(values);
       }
     },
     onFinishFailed,

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -137,7 +137,7 @@ export type NotifyInfo =
 export interface Callbacks {
   onValuesChange?: (changedValues: Store, values: Store) => void;
   onFieldsChange?: (changedFields: FieldData[], allFields: FieldData[]) => void;
-  onFinish?: (values: Store) => void;
+  onFinish?: (values: Store) => Promise<any> | undefined;
   onFinishFailed?: (errorInfo: ValidateErrorEntity) => void;
 }
 

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -593,27 +593,22 @@ export class FormStore {
   };
 
   // ============================ Submit ============================
-  private submit = () => {
+  private submit = async () => {
     this.warningUnhooked();
 
-    this.validateFields()
-      .then(values => {
-        const { onFinish } = this.callbacks;
-        if (onFinish) {
-          try {
-            onFinish(values);
-          } catch (err) {
-            // Should print error if user `onFinish` callback failed
-            console.error(err);
-          }
-        }
-      })
-      .catch(e => {
-        const { onFinishFailed } = this.callbacks;
-        if (onFinishFailed) {
-          onFinishFailed(e);
-        }
-      });
+    try {
+      const values = await this.validateFields();
+      const { onFinish } = this.callbacks;
+
+      if (onFinish) {
+        onFinish(values);
+      }
+    } catch (error) {
+      const { onFinishFailed } = this.callbacks;
+      if (onFinishFailed) {
+        onFinishFailed(error);
+      }
+    }
   };
 }
 

--- a/tests/validate.test.js
+++ b/tests/validate.test.js
@@ -363,13 +363,14 @@ describe('Form.Validate', () => {
   });
 
   it('should error in console if user script failed', async () => {
-    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const onFinishFailedMock = jest.fn();
 
     const wrapper = mount(
       <Form
         onFinish={() => {
           throw new Error('should console this');
         }}
+        onFinishFailed={onFinishFailedMock}
         initialValues={{ user: 'light' }}
       >
         <InfoField name="user">
@@ -380,9 +381,9 @@ describe('Form.Validate', () => {
 
     wrapper.find('form').simulate('submit');
     await timeout();
-    expect(errorSpy.mock.calls[0][0].message).toEqual('should console this');
+    expect(onFinishFailedMock.mock.calls[0][0].message).toEqual('should console this');
 
-    errorSpy.mockRestore();
+    onFinishFailedMock.mockRestore();
   });
 
   it('validateFirst', async () => {


### PR DESCRIPTION
有种场景，我在 Modal 中封装 Form, onFinish 调用接口，当我调用 submit 的时候我希望是在 onFinish 结束之后才会进行下一步操作