### PR TITLE
feat: support getValueProps 

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,17 +76,18 @@ We use typescript to create the Type definition. You can view directly in IDE. B
 
 ## Field
 
-| Prop              | Description                             | Type                                      | Default  |
-| ----------------- | --------------------------------------- | ----------------------------------------- | -------- |
-| dependencies      | Will re-render if dependencies changed  | [NamePath](#namepath)[]                   | -        |
-| getValueFromEvent | Specify how to get value from event     | (..args: any[]) => any                    | -        |
-| name              | Field name path                         | [NamePath](#namepath)                     | -        |
-| normalize         | Normalize value before update           | (value, prevValue, prevValues) => any     | -        |
-| rules             | Validate rules                          | [Rule](#rule)[]                           | -        |
-| shouldUpdate      | Check if Field should update            | true \| (prevValues, nextValues): boolean | -        |
-| trigger           | Collect value update by event trigger   | string                                    | onChange |
-| validateTrigger   | Config trigger point with rule validate | string \| string[]                        | onChange |
-| valuePropName     | Config value mapping prop with element  | string                                    | value    |
+| Prop              | Description                                                                   | Type                                      | Default  |
+| ----------------- | ----------------------------------------------------------------------------- | ----------------------------------------- | -------- |
+| dependencies      | Will re-render if dependencies changed                                        | [NamePath](#namepath)[]                   | -        |
+| getValueFromEvent | Specify how to get value from event                                           | (..args: any[]) => any                    | -        |
+| getValueProps     | Customize additional props with value. This prop will disable `valuePropName` | (value) => any                            | -        |
+| name              | Field name path                                                               | [NamePath](#namepath)                     | -        |
+| normalize         | Normalize value before update                                                 | (value, prevValue, prevValues) => any     | -        |
+| rules             | Validate rules                                                                | [Rule](#rule)[]                           | -        |
+| shouldUpdate      | Check if Field should update                                                  | true \| (prevValues, nextValues): boolean | -        |
+| trigger           | Collect value update by event trigger                                         | string                                    | onChange |
+| validateTrigger   | Config trigger point with rule validate                                       | string \| string[]                        | onChange |
+| valuePropName     | Config value mapping prop with element                                        | string                                    | value    |
 
 ## List
 

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -68,6 +68,7 @@ export interface InternalFieldProps {
   validateTrigger?: string | string[] | false;
   validateFirst?: boolean;
   valuePropName?: string;
+  getValueProps?: (value: StoreValue) => object;
   messageVariables?: Record<string, string>;
   onReset?: () => void;
 }
@@ -366,18 +367,26 @@ class Field extends React.Component<InternalFieldProps, FieldState> implements F
   };
 
   public getControlled = (childProps: ChildProps = {}) => {
-    const { trigger, validateTrigger, getValueFromEvent, normalize, valuePropName } = this.props;
+    const {
+      trigger,
+      validateTrigger,
+      getValueFromEvent,
+      normalize,
+      valuePropName,
+      getValueProps,
+    } = this.props;
     const namePath = this.getNamePath();
     const { getInternalHooks, getFieldsValue }: InternalFormInstance = this.context;
     const { dispatch } = getInternalHooks(HOOK_MARK);
     const value = this.getValue();
+    const mergedGetValueProps = getValueProps || ((val: StoreValue) => ({ [valuePropName]: val }));
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const originTriggerFunc: any = childProps[trigger];
 
     const control = {
       ...childProps,
-      [valuePropName]: value,
+      ...mergedGetValueProps(value),
     };
 
     // Add trigger

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -42,9 +42,7 @@ describe('Form.Basic', () => {
 
       it('use component', () => {
         const MyComponent = ({ children }) => <div>{children}</div>;
-        const wrapper = mount(
-          <Form component={MyComponent}>{renderContent()}</Form>,
-        );
+        const wrapper = mount(<Form component={MyComponent}>{renderContent()}</Form>);
         expect(wrapper.find('form').length).toBe(0);
         expect(wrapper.find(MyComponent).length).toBe(1);
         expect(wrapper.find('input').length).toBe(2);
@@ -111,11 +109,7 @@ describe('Form.Basic', () => {
                 form = instance;
               }}
             >
-              <Field
-                name="username"
-                rules={[{ required: true }]}
-                onReset={onReset}
-              >
+              <Field name="username" rules={[{ required: true }]} onReset={onReset}>
                 <Input />
               </Field>
             </Form>
@@ -137,9 +131,7 @@ describe('Form.Basic', () => {
 
         await changeValue(getField(wrapper, 'username'), '');
         expect(form.getFieldValue('username')).toEqual('');
-        expect(form.getFieldError('username')).toEqual([
-          "'username' is required",
-        ]);
+        expect(form.getFieldError('username')).toEqual(["'username' is required"]);
         expect(form.isFieldTouched('username')).toBeTruthy();
 
         expect(onReset).not.toHaveBeenCalled();
@@ -183,9 +175,7 @@ describe('Form.Basic', () => {
       expect(form.getFieldError('username')).toEqual([]);
       expect(form.isFieldTouched('username')).toBeFalsy();
       expect(form.getFieldValue('password')).toEqual('');
-      expect(form.getFieldError('password')).toEqual([
-        "'password' is required",
-      ]);
+      expect(form.getFieldError('password')).toEqual(["'password' is required"]);
       expect(form.isFieldTouched('password')).toBeTruthy();
     });
   });
@@ -337,13 +327,8 @@ describe('Form.Basic', () => {
     );
 
     await changeValue(getField(wrapper), 'Bamboo');
-    expect(onValuesChange).toHaveBeenCalledWith(
-      { username: 'Bamboo' },
-      { username: 'Bamboo' },
-    );
-    expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({ target: { value: 'Bamboo' } }),
-    );
+    expect(onValuesChange).toHaveBeenCalledWith({ username: 'Bamboo' }, { username: 'Bamboo' });
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ target: { value: 'Bamboo' } }));
   });
 
   it('submit', async () => {
@@ -422,17 +407,27 @@ describe('Form.Basic', () => {
       </div>,
     );
 
-    wrapper
-      .find('input[type="checkbox"]')
-      .simulate('change', { target: { checked: true } });
+    wrapper.find('input[type="checkbox"]').simulate('change', { target: { checked: true } });
     await timeout();
     expect(form.getFieldsValue()).toEqual({ check: true });
 
-    wrapper
-      .find('input[type="checkbox"]')
-      .simulate('change', { target: { checked: false } });
+    wrapper.find('input[type="checkbox"]').simulate('change', { target: { checked: false } });
     await timeout();
     expect(form.getFieldsValue()).toEqual({ check: false });
+  });
+
+  it('getValueProps', async () => {
+    const wrapper = mount(
+      <div>
+        <Form initialValues={{ test: 'bamboo' }}>
+          <Field name="test" getValueProps={val => ({ light: val })}>
+            <span className="anything" />
+          </Field>
+        </Form>
+      </div>,
+    );
+
+    expect(wrapper.find('.anything').props().light).toEqual('bamboo');
   });
 
   it('shouldUpdate', async () => {
@@ -450,8 +445,7 @@ describe('Form.Basic', () => {
         <Field shouldUpdate>
           {(_, __, { getFieldsError, isFieldsTouched }) => {
             isAllTouched = isFieldsTouched(true);
-            hasError = getFieldsError().filter(({ errors }) => errors.length)
-              .length;
+            hasError = getFieldsError().filter(({ errors }) => errors.length).length;
 
             return null;
           }}
@@ -528,9 +522,7 @@ describe('Form.Basic', () => {
       triggerUpdate.mockReset();
 
       // Not trigger render
-      formRef.current.setFields([
-        { name: 'others', value: 'no need to update' },
-      ]);
+      formRef.current.setFields([{ name: 'others', value: 'no need to update' }]);
       wrapper.update();
       expect(triggerUpdate).not.toHaveBeenCalled();
 
@@ -579,10 +571,7 @@ describe('Form.Basic', () => {
             form = instance;
           }}
         >
-          <Field
-            name="normal"
-            rules={[{ validator: () => new Promise(() => {}) }]}
-          >
+          <Field name="normal" rules={[{ validator: () => new Promise(() => {}) }]}>
             {(control, meta) => {
               currentMeta = meta;
               return <Input {...control} />;
@@ -684,25 +673,16 @@ describe('Form.Basic', () => {
 
     expect(
       form.getFieldsValue(null, meta => {
-        expect(Object.keys(meta)).toEqual([
-          'touched',
-          'validating',
-          'errors',
-          'name',
-        ]);
+        expect(Object.keys(meta)).toEqual(['touched', 'validating', 'errors', 'name']);
         return false;
       }),
     ).toEqual({});
 
-    expect(form.getFieldsValue(null, () => true)).toEqual(
-      form.getFieldsValue(),
-    );
+    expect(form.getFieldsValue(null, () => true)).toEqual(form.getFieldsValue());
     expect(form.getFieldsValue(null, meta => meta.touched)).toEqual({});
 
     await changeValue(getField(wrapper, 0), 'Bamboo');
-    expect(form.getFieldsValue(null, () => true)).toEqual(
-      form.getFieldsValue(),
-    );
+    expect(form.getFieldsValue(null, () => true)).toEqual(form.getFieldsValue());
     expect(form.getFieldsValue(null, meta => meta.touched)).toEqual({
       username: 'Bamboo',
     });


### PR DESCRIPTION
原本看和 `valuePropName` 比较雷同，就去掉了。现在看看（包括业务上的反馈）有一些特殊的用法还是需要的。

resolve https://github.com/ant-design/ant-design/issues/22896
resolve https://github.com/ant-design/ant-design/issues/19727