### PR TITLE
fix: List should not crash when it's not a array value

### DIFF
--- a/src/List.tsx
+++ b/src/List.tsx
@@ -97,8 +97,17 @@ const List: React.FunctionComponent<ListProps> = ({ name, children }) => {
             },
           };
 
+          let listValue = value || [];
+          if (!Array.isArray(listValue)) {
+            listValue = [];
+
+            if (process.env.NODE_ENV !== 'production') {
+              warning(false, `Current value of '${prefixName.join(' > ')}' is not an array type.`);
+            }
+          }
+
           return children(
-            (value as StoreValue[]).map(
+            (listValue as StoreValue[]).map(
               (__, index): ListField => {
                 let key = keyManager.keys[index];
                 if (key === undefined) {

--- a/tests/list.test.js
+++ b/tests/list.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
+import { resetWarned } from 'rc-util/lib/warning';
 import Form, { Field, List } from '../src';
 import { Input } from './common/InfoField';
 import { changeValue, getField } from './common';
@@ -65,6 +66,26 @@ describe('Form.List', () => {
     expect(form.getFieldsValue()).toEqual({
       list: ['111', '222', '333'],
     });
+  });
+
+  it('not crash', () => {
+    // Empty only
+    mount(
+      <Form initialValues={{ list: null }}>
+        <Form.List name="list">{() => null}</Form.List>
+      </Form>,
+    );
+
+    // Not a array
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    resetWarned();
+    mount(
+      <Form initialValues={{ list: {} }}>
+        <Form.List name="list">{() => null}</Form.List>
+      </Form>,
+    );
+    expect(errorSpy).toHaveBeenCalledWith("Warning: Current value of 'list' is not an array type.");
+    errorSpy.mockRestore();
   });
 
   it('operation', async () => {


### PR DESCRIPTION
fix a crash like:
`form.setFieldsValue({ list: null })`