### PR TITLE
fix: `getFieldsValue` shouldn't always return `any`

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -194,7 +194,7 @@ export interface FormInstance<Values = any> {
   getFieldsValue: (
     nameList?: NamePath[] | true,
     filterFunc?: (meta: Meta) => boolean,
-  ) => Values | any;
+  ) => Values;
   getFieldError: (name: NamePath) => string[];
   getFieldsError: (nameList?: NamePath[]) => FieldError[];
   isFieldsTouched(nameList?: NamePath[], allFieldsTouched?: boolean): boolean;


### PR DESCRIPTION
Values | any 和 any 是一样的，结果会导致类型推断失效