### PR TITLE
fix: Nest Field will trigger clean all store when `preserve=false`

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -500,7 +500,7 @@ export class FormStore {
       const mergedPreserve = preserve !== undefined ? preserve : this.preserve;
       if (mergedPreserve === false && !isListField) {
         const namePath = entity.getNamePath();
-        if (this.getFieldValue(namePath) !== undefined) {
+        if (namePath.length && this.getFieldValue(namePath) !== undefined) {
           this.store = setValue(this.store, namePath, undefined);
         }
       }

--- a/tests/preserve.test.tsx
+++ b/tests/preserve.test.tsx
@@ -137,5 +137,35 @@ describe('Form.Preserve', () => {
 
     errorSpy.mockRestore();
   });
+
+  it('nest render props should not clean full store', () => {
+    let form: FormInstance;
+
+    const wrapper = mount(
+      <Form
+        preserve={false}
+        ref={instance => {
+          form = instance;
+        }}
+      >
+        <Form.Field name="light">
+          <input />
+        </Form.Field>
+        <Form.Field shouldUpdate>
+          {(_, __, { getFieldValue }) =>
+            getFieldValue('light') === 'bamboo' ? <Form.Field>{() => null}</Form.Field> : null
+          }
+        </Form.Field>
+      </Form>,
+    );
+
+    wrapper.find('input').simulate('change', { target: { value: 'bamboo' } });
+    expect(form.getFieldsValue()).toEqual({ light: 'bamboo' });
+
+    wrapper.find('input').simulate('change', { target: { value: 'little' } });
+    expect(form.getFieldsValue()).toEqual({ light: 'little' });
+
+    wrapper.unmount();
+  });
 });
 /* eslint-enable no-template-curly-in-string */


### PR DESCRIPTION
resolve https://github.com/ant-design/ant-design/issues/27581