### PR TITLE
fix: Nest Field.List item will not clean up on `onValuesChange` when removed

### DIFF
--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -359,6 +359,8 @@ class Field extends React.Component<InternalFieldProps, FieldState> implements F
 
   public getErrors = () => this.errors;
 
+  public isListField = () => this.props.isListField;
+
   // ============================= Child Component =============================
   public getMeta = (): Meta => {
     // Make error & validating in cache to save perf

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -5,19 +5,19 @@ import FieldContext from './FieldContext';
 import Field from './Field';
 import { move, getNamePath } from './utils/valueUtil';
 
-interface ListField {
+export interface ListField {
   name: number;
   key: number;
   isListField: boolean;
 }
 
-interface ListOperations {
+export interface ListOperations {
   add: (defaultValue?: StoreValue, index?: number) => void;
   remove: (index: number | number[]) => void;
   move: (from: number, to: number) => void;
 }
 
-interface ListProps {
+export interface ListProps {
   name: NamePath;
   rules?: ValidatorRule[];
   validateTrigger?: string | string[] | false;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,6 +25,6 @@ RefForm.Field = Field;
 RefForm.List = List;
 RefForm.useForm = useForm;
 
-export { FormInstance, Field, List, useForm, FormProvider };
+export { FormInstance, Field, List, useForm, FormProvider, FormProps };
 
 export default RefForm;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -97,6 +97,7 @@ export interface FieldEntity {
   isFieldTouched: () => boolean;
   isFieldDirty: () => boolean;
   isFieldValidating: () => boolean;
+  isListField: () => boolean;
   validateRules: (options?: ValidateOptions) => Promise<string[]>;
   getMeta: () => Meta;
   getNamePath: () => InternalNamePath;

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -211,6 +211,12 @@ export class FormStore {
       const namePath =
         'INVALIDATE_NAME_PATH' in entity ? entity.INVALIDATE_NAME_PATH : entity.getNamePath();
 
+        // Ignore when it's a list item and not specific the namePath,
+        // since parent field is already take in count
+        if (!nameList && (entity as FieldEntity).isListField?.()) {
+          return;
+        }
+
       if (!filterFunc) {
         filteredNameList.push(namePath);
       } else {
@@ -220,6 +226,8 @@ export class FormStore {
         }
       }
     });
+
+    console.log('>>>', filteredNameList);
 
     return cloneByNamePathList(this.store, filteredNameList.map(getNamePath));
   };

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -227,8 +227,6 @@ export class FormStore {
       }
     });
 
-    console.log('>>>', filteredNameList);
-
     return cloneByNamePathList(this.store, filteredNameList.map(getNamePath));
   };
 

--- a/tests/list.test.tsx
+++ b/tests/list.test.tsx
@@ -644,6 +644,6 @@ describe('Form.List', () => {
     );
 
     wrapper.find('button').simulate('click');
-    expect(onValuesChange).toHaveBeenCalledWith(expect.anything(), {list: [{ first: 'light' }]});
+    expect(onValuesChange).toHaveBeenCalledWith(expect.anything(), { list: [{ first: 'light' }] });
   });
 });

--- a/tests/list.test.tsx
+++ b/tests/list.test.tsx
@@ -8,7 +8,6 @@ import { Meta } from '../src/interface';
 import { Input } from './common/InfoField';
 import { changeValue, getField } from './common';
 import timeout from './common/timeout';
-import { wrap } from 'lodash';
 
 describe('Form.List', () => {
   let form;
@@ -620,7 +619,7 @@ describe('Form.List', () => {
   it('Nest list remove should trigger correct onValuesChange', () => {
     const onValuesChange = jest.fn();
 
-    const [wrapper, getList] = generateForm(
+    const [wrapper] = generateForm(
       (fields, operation) => (
         <div>
           {fields.map(field => (
@@ -645,6 +644,6 @@ describe('Form.List', () => {
     );
 
     wrapper.find('button').simulate('click');
-    expect(onValuesChange).toHaveBeenCalledWith(expect.anything(), [{ first: 'light' }]);
+    expect(onValuesChange).toHaveBeenCalledWith(expect.anything(), {list: [{ first: 'light' }]});
   });
 });


### PR DESCRIPTION
resolve https://github.com/ant-design/ant-design/issues/27576