### PR TITLE
Fix issue with NPM 7 throwing error

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "now-build": "npm run build"
   },
   "peerDependencies": {
-    "react": "^16.9.0"
+    "react": ">= 16.9.0"
   },
   "devDependencies": {
     "@types/enzyme": "^3.10.5",


### PR DESCRIPTION
NPM 7 automatically installs peer dependencies. Trying to update to React 17 causes error when installing @ant-design/icons
More info here: https://github.blog/2020-10-13-presenting-v7-0-0-of-the-npm-cli/

Based on the advice from Kent C. Dodds and Cory House, I updated peer dependency of React to be ">= 16.9.0"
Tweets: https://mobile.twitter.com/kentcdodds/status/1325565636303482880