### PR TITLE
fix: custom trigger of field should work

### DIFF
--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -475,12 +475,10 @@ class Field extends React.Component<InternalFieldProps, FieldState> implements F
         newValue = normalize(newValue, value, getFieldsValue(true));
       }
 
-      return newValue
-    }
+      return newValue;
+    };
     // only update values
     control.onChange = (...args: EventArgs) => {
-      if (trigger === 'onChange') return
-
       const newValue = getNewValue(...args);
 
       dispatch({
@@ -493,7 +491,7 @@ class Field extends React.Component<InternalFieldProps, FieldState> implements F
       if (originChangeFunc) {
         originChangeFunc(...args);
       }
-    }
+    };
 
     // Add trigger
     control[trigger] = (...args: EventArgs) => {

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -40,6 +40,7 @@ interface UpdateAction {
   type: 'updateValue';
   namePath: InternalNamePath;
   value: StoreValue;
+  collect?: boolean;
 }
 
 interface ValidateAction {
@@ -552,8 +553,8 @@ export class FormStore {
   private dispatch = (action: ReducerAction) => {
     switch (action.type) {
       case 'updateValue': {
-        const { namePath, value } = action;
-        this.updateValue(namePath, value);
+        const { namePath, value, collect } = action;
+        this.updateValue(namePath, value, collect);
         break;
       }
       case 'validateField': {
@@ -584,7 +585,7 @@ export class FormStore {
     }
   };
 
-  private updateValue = (name: NamePath, value: StoreValue) => {
+  private updateValue = (name: NamePath, value: StoreValue, collect: boolean = true) => {
     const namePath = getNamePath(name);
     const prevStore = this.store;
     this.store = setValue(this.store, namePath, value);
@@ -593,6 +594,8 @@ export class FormStore {
       type: 'valueUpdate',
       source: 'internal',
     });
+
+    if (!collect) return
 
     // Notify dependencies children with parent update
     // We need delay to trigger validate in case Field is under render props

--- a/tests/field.test.tsx
+++ b/tests/field.test.tsx
@@ -26,4 +26,75 @@ describe('Form.Field', () => {
     expect(instance.cancelRegisterFunc).toBeFalsy();
     expect((wrapper.find('Field').instance() as any).cancelRegisterFunc).toBeTruthy();
   });
+  describe('trigger', () => {
+    const Input = ({ value = '', ...props }: any) => {
+      return <input value={value} {...props} />;
+    };
+
+    const Demo = ({
+      trigger,
+      onValuesChange,
+      onChange,
+    }: {
+      trigger?: string;
+      onValuesChange?: jest.Mock<any, any>;
+      onChange?: jest.Mock<any, any>;
+    }) => {
+      const [form] = Form.useForm();
+
+      return (
+        <Form onValuesChange={onValuesChange} form={form}>
+          <Field name="light" trigger={trigger}>
+            <Input onChange={onChange} placeholder="light" />
+          </Field>
+        </Form>
+      );
+    };
+
+    it('default is onChange', () => {
+      const onValuesChange = jest.fn();
+      const wrapper = mount(<Demo onValuesChange={onValuesChange} />);
+
+      const input = wrapper.find('input');
+      input.simulate('change', {
+        target: {
+          value: '123',
+        },
+      });
+      expect(onValuesChange.mock.calls[0][0]).toMatchObject({
+        light: '123',
+      });
+    });
+    it('onBlur should work correctly', () => {
+      const onValuesChange = jest.fn();
+      const originOnChange = jest.fn();
+      const wrapper = mount(
+        <Demo onChange={originOnChange} trigger="onBlur" onValuesChange={onValuesChange} />,
+      );
+      const input = wrapper.find('input');
+      input.simulate('change', {
+        target: {
+          value: '123',
+        },
+      });
+      expect(onValuesChange).not.toHaveBeenCalled();
+      // origin onChange should be called
+      expect(originOnChange).toHaveBeenCalledTimes(1);
+      expect(originOnChange.mock.calls[0][0]).toMatchObject({
+        target: {
+          value: '123',
+        },
+      });
+
+      input.simulate('blur', {
+        target: {
+          value: '234',
+        },
+      });
+      expect(onValuesChange).toHaveBeenCalledTimes(1);
+      expect(onValuesChange.mock.calls[0][0]).toMatchObject({
+        light: '234',
+      });
+    });
+  });
 });


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/26185

### 问题原因

之前是根据 `trigger` 给 field 的子控件添加回调事件监听，但是因为受控组件值更新依赖的回调事件是 `onChange`，因此当 `trigger` 不是 onChange 时，子控件的 onChange 事件没有监听，值更新失败。

### 解决方案

始终给 field 的子控件添加一个 onChange 监听，内部只更新 store 中的值，不做其他验证、执行 onValuesChange 等操作。

在根据 trigger 给子控件添加回调，此回调的逻辑与原来相同，此时子控件的值已经为最新值，如果 trigger 为 onChange，则会覆盖原来的 onChange 监听。

### 可能存在的问题

目前在给 field 添加的 onChange 监听中 store 中的更新逻辑是这样的：

https://github.com/react-component/field-form/blob/7ecc973c8e3902cd515022aaa86904f1b6b7dbf2/src%2FuseForm.ts#L598

不知道会不会有问题? @zombieJ @afc163 