### PR TITLE
chore(deps-dev): bump react-router from 3.0.0 to 5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "react-dnd-html5-backend": "^8.0.3",
     "react-dom": "^16.14.0",
     "react-redux": "^4.4.10",
-    "react-router": "^3.0.0",
+    "react-router": "^5.2.0",
     "redux": "^3.7.2",
     "typescript": "^3.5.2"
   }


### PR DESCRIPTION
fix issue [#244](https://github.com/react-component/field-form/issues/244) 
and issue [#239](https://github.com/react-component/field-form/issues/239)