### PR TITLE
feat: Form.List nest Field.Item support `preserve={false}`

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@babel/runtime": "^7.8.4",
     "async-validator": "^3.0.3",
-    "rc-util": "^5.0.0"
+    "rc-util": "^5.8.0"
   },
   "devDependencies": {
     "@types/enzyme": "^3.10.5",

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -107,7 +107,11 @@ class Field extends React.Component<InternalFieldProps, FieldState> implements F
     resetCount: 0,
   };
 
-  private cancelRegisterFunc: (isListField?: boolean, preserve?: boolean) => void | null = null;
+  private cancelRegisterFunc: (
+    isListField?: boolean,
+    preserve?: boolean,
+    namePath?: InternalNamePath,
+  ) => void | null = null;
 
   private mounted = false;
 
@@ -162,10 +166,10 @@ class Field extends React.Component<InternalFieldProps, FieldState> implements F
   }
 
   public cancelRegister = () => {
-    const { preserve, isListField } = this.props;
+    const { preserve, isListField, name } = this.props;
 
     if (this.cancelRegisterFunc) {
-      this.cancelRegisterFunc(isListField, preserve);
+      this.cancelRegisterFunc(isListField, preserve, getNamePath(name));
     }
     this.cancelRegisterFunc = null;
   };

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -553,11 +553,15 @@ function WrapperField<Values = any>({ name, ...restProps }: FieldProps<Values>) 
     key = `_${(namePath || []).join('_')}`;
   }
 
-  if (process.env.NODE_ENV !== 'production') {
-    warning(
-      restProps.preserve !== false || !restProps.isListField,
-      '`preserve` should not apply on Form.List fields.',
-    );
+  // Warning if it's a directly list field.
+  // We can still support multiple level field preserve.
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    restProps.preserve === false &&
+    restProps.isListField &&
+    namePath.length <= 1
+  ) {
+    warning(false, '`preserve` should not apply on Form.List fields.');
   }
 
   return <Field key={key} name={namePath} {...restProps} fieldContext={fieldContext} />;

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -541,8 +541,9 @@ export class FormStore {
 
       // Clean up store value if not preserve
       const mergedPreserve = preserve !== undefined ? preserve : this.preserve;
+      const namePath = entity.getNamePath();
+
       if (mergedPreserve === false && !isListField) {
-        const namePath = entity.getNamePath();
         const defaultValue = getValue(this.initialValues, namePath);
 
         if (

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -536,14 +536,14 @@ export class FormStore {
     }
 
     // un-register field callback
-    return (isListField?: boolean, preserve?: boolean) => {
+    return (isListField?: boolean, preserve?: boolean, subNamePath: InternalNamePath = []) => {
       this.fieldEntities = this.fieldEntities.filter(item => item !== entity);
 
       // Clean up store value if not preserve
       const mergedPreserve = preserve !== undefined ? preserve : this.preserve;
-      const namePath = entity.getNamePath();
 
-      if (mergedPreserve === false && !isListField) {
+      if (mergedPreserve === false && (!isListField || subNamePath.length > 1)) {
+        const namePath = entity.getNamePath();
         const defaultValue = getValue(this.initialValues, namePath);
 
         if (

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -544,7 +544,8 @@ export class FormStore {
 
       if (mergedPreserve === false && (!isListField || subNamePath.length > 1)) {
         const namePath = entity.getNamePath();
-        const defaultValue = getValue(this.initialValues, namePath);
+
+        const defaultValue = isListField ? undefined : getValue(this.initialValues, namePath);
 
         if (
           namePath.length &&
@@ -555,7 +556,7 @@ export class FormStore {
               !matchNamePath(field.getNamePath(), namePath),
           )
         ) {
-          this.store = setValue(this.store, namePath, defaultValue);
+          this.store = setValue(this.store, namePath, defaultValue, true);
         }
       }
     };

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -539,7 +539,7 @@ export class FormStore {
     return (isListField?: boolean, preserve?: boolean) => {
       this.fieldEntities = this.fieldEntities.filter(item => item !== entity);
 
-      // Clean up store value if preserve
+      // Clean up store value if not preserve
       const mergedPreserve = preserve !== undefined ? preserve : this.preserve;
       if (mergedPreserve === false && !isListField) {
         const namePath = entity.getNamePath();

--- a/src/utils/valueUtil.ts
+++ b/src/utils/valueUtil.ts
@@ -19,8 +19,13 @@ export function getValue(store: Store, namePath: InternalNamePath) {
   return value;
 }
 
-export function setValue(store: Store, namePath: InternalNamePath, value: StoreValue): Store {
-  const newStore = set(store, namePath, value);
+export function setValue(
+  store: Store,
+  namePath: InternalNamePath,
+  value: StoreValue,
+  removeIfUndefined = false,
+): Store {
+  const newStore = set(store, namePath, value, removeIfUndefined);
   return newStore;
 }
 

--- a/tests/preserve.test.tsx
+++ b/tests/preserve.test.tsx
@@ -186,7 +186,7 @@ describe('Form.Preserve', () => {
 
       const wrapper = mount(
         <Form
-          initialValues={{ list: [{ type: 'light', light: '1128' }] }}
+          initialValues={{ list: [{ type: 'light' }] }}
           preserve={false}
           ref={instance => {
             form = instance;
@@ -202,11 +202,21 @@ describe('Form.Preserve', () => {
                   <Form.Field shouldUpdate>
                     {(_, __, { getFieldValue }) =>
                       getFieldValue(['list', field.name, 'type']) === 'light' ? (
-                        <Form.Field {...field} name={[field.name, 'light']}>
+                        <Form.Field
+                          {...field}
+                          key="light"
+                          preserve={false}
+                          name={[field.name, 'light']}
+                        >
                           <input />
                         </Form.Field>
                       ) : (
-                        <Form.Field {...field} name={[field.name, 'bamboo']}>
+                        <Form.Field
+                          {...field}
+                          key="bamboo"
+                          preserve={false}
+                          name={[field.name, 'bamboo']}
+                        >
                           <input />
                         </Form.Field>
                       )
@@ -219,6 +229,12 @@ describe('Form.Preserve', () => {
         </Form>,
       );
 
+      // Change value
+      wrapper
+        .find('input')
+        .last()
+        .simulate('change', { target: { value: '1128' } });
+
       // Change type
       wrapper
         .find('input')
@@ -230,7 +246,7 @@ describe('Form.Preserve', () => {
         .last()
         .simulate('change', { target: { value: '903' } });
 
-      expect(form.getFieldsValue()).toEqual(233);
+      expect(form.getFieldsValue()).toEqual({ list: [{ type: 'bamboo', bamboo: '903' }] });
     });
   });
 


### PR DESCRIPTION
ref https://github.com/ant-design/ant-design/issues/29215

嵌套子字段可以通过 `preserve={false}` 在移除时删掉对应字段，需要发个 minor。