### PR TITLE
fix: scrollToFirstError dont work

### DIFF
--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {
+import type {
   Store,
   FormInstance,
   FieldData,
@@ -9,7 +9,8 @@ import {
 } from './interface';
 import useForm from './useForm';
 import FieldContext, { HOOK_MARK } from './FieldContext';
-import FormContext, { FormContextProps } from './FormContext';
+import type { FormContextProps } from './FormContext';
+import FormContext from './FormContext';
 import { isSimilar } from './utils/valueUtil';
 
 type BaseFormProps = Omit<React.FormHTMLAttributes<HTMLFormElement>, 'onSubmit'>;
@@ -31,6 +32,7 @@ export interface FormProps<Values = any> extends BaseFormProps {
   onFinishFailed?: Callbacks<Values>['onFinishFailed'];
   validateTrigger?: string | string[] | false;
   preserve?: boolean;
+  getFormDom?: (formDom: HTMLElement) => void;
 }
 
 const Form: React.ForwardRefRenderFunction<FormInstance, FormProps> = (
@@ -48,6 +50,7 @@ const Form: React.ForwardRefRenderFunction<FormInstance, FormProps> = (
     onFieldsChange,
     onFinish,
     onFinishFailed,
+    getFormDom,
     ...restProps
   }: FormProps,
   ref,
@@ -152,6 +155,9 @@ const Form: React.ForwardRefRenderFunction<FormInstance, FormProps> = (
         event.stopPropagation();
 
         formInstance.submit();
+      }}
+      ref={(formRef: HTMLElement) => {
+        if (getFormDom) getFormDom(formRef);
       }}
     >
       {wrapperNode}


### PR DESCRIPTION
提供一个ref给antd，处理bug ant-design/ant-design#28869 的问题，方案是使用dom去定位scroll的，需要你评估