### PR TITLE
Fix the validation of array fields with defaultField

### DIFF
--- a/src/utils/validateUtil.ts
+++ b/src/utils/validateUtil.ts
@@ -1,7 +1,7 @@
 import RawAsyncValidator from 'async-validator';
 import * as React from 'react';
 import warning from 'rc-util/lib/warning';
-import {
+import type {
   InternalNamePath,
   ValidateOptions,
   ValidateMessages,
@@ -110,7 +110,7 @@ async function validateRule(
     }
   }
 
-  if (!result.length && subRuleField) {
+  if (!result.length && subRuleField && Array.isArray(value)) {
     const subResults: string[][] = await Promise.all(
       (value as StoreValue[]).map((subValue: StoreValue, i: number) =>
         validateRule(`${name}.${i}`, subValue, subRuleField, options, messageVariables),

--- a/tests/legacy/validate-array.test.js
+++ b/tests/legacy/validate-array.test.js
@@ -1,9 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import Form, { Field } from '../../src';
-import { Input } from '../common/InfoField';
-import { changeValue, getField, matchArray } from '../common';
-import timeout from '../common/timeout';
+import { matchArray } from '../common';
 
 describe('legacy.validate-array', () => {
   const MyInput = ({ value = [''], onChange, ...props }) => (
@@ -54,5 +52,35 @@ describe('legacy.validate-array', () => {
         'name',
       );
     }
+  });
+
+  it('validates an unrequired type array which is undefined', async () => {
+    let form;
+
+    mount(
+      <div>
+        <Form
+          ref={instance => {
+            form = instance;
+          }}
+        >
+          <Field
+            name="unrequired_array"
+            rules={[
+              {
+                message: 'The tags must be strings',
+                type: 'array',
+                defaultField: { type: 'string' },
+              },
+            ]}
+          >
+            <MyInput />
+          </Field>
+        </Form>
+      </div>,
+    );
+
+    const values = await form.validateFields();
+    expect(values.unrequired_array).toBe(undefined);
   });
 });


### PR DESCRIPTION
async-validator allows undefined array fields containing a defaultField
definition, as long as these are not required. Without this fix an error
is thrown by calling map() on undefined. Therefore, an additional check
is implemented before validating the elements of the array.

A test case is included in this commit.

Thanks for providing this useful piece of sofware!