### PR TITLE
chore: update types

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,11 +1,16 @@
 import type { ReactElement } from 'react';
+import type {
+  Value as StoreValue,
+  Values as Store,
+  RuleType,
+  ValidateMessages,
+} from 'async-validator';
 import type { ReducerAction } from './useForm';
 
 export type InternalNamePath = (string | number)[];
 export type NamePath = string | number | InternalNamePath;
 
-export type StoreValue = any;
-export type Store = Record<string, StoreValue>;
+export type { RuleType, StoreValue, Store, ValidateMessages };
 
 export interface Meta {
   touched: boolean;
@@ -26,25 +31,10 @@ export interface FieldData extends Partial<Omit<InternalFieldData, 'name'>> {
   name: NamePath;
 }
 
-export type RuleType =
-  | 'string'
-  | 'number'
-  | 'boolean'
-  | 'method'
-  | 'regexp'
-  | 'integer'
-  | 'float'
-  | 'object'
-  | 'enum'
-  | 'date'
-  | 'url'
-  | 'hex'
-  | 'email';
-
 type Validator = (
-  rule: RuleObject,
+  rule: InternalRule,
   value: StoreValue,
-  callback: (error?: string) => void,
+  callback: (error?: string | Error) => void,
 ) => Promise<void | any> | void;
 
 export type RuleRender = (form: FormInstance) => RuleObject;
@@ -67,21 +57,22 @@ interface BaseRule {
   transform?: (value: StoreValue) => StoreValue;
   type?: RuleType;
   whitespace?: boolean;
+  defaultField?: RuleObject;
+  fields?: Record<string, RuleObject>;
 
   /** Customize rule level `validateTrigger`. Must be subset of Field `validateTrigger` */
   validateTrigger?: string | string[];
 }
 
-type AggregationRule = BaseRule & Partial<ValidatorRule>;
-
-interface ArrayRule extends Omit<AggregationRule, 'type'> {
-  type: 'array';
-  defaultField?: RuleObject;
-}
-
-export type RuleObject = AggregationRule | ArrayRule;
+export type RuleObject = BaseRule & Partial<ValidatorRule>;
 
 export type Rule = RuleObject | RuleRender;
+
+export interface InternalRule extends Omit<RuleObject, 'validator'> {
+  field?: string;
+  fullField?: string;
+  fullFields?: string[];
+}
 
 export interface ValidateErrorEntity<Values = any> {
   values: Values;
@@ -265,52 +256,3 @@ export type InternalFormInstance = Omit<FormInstance, 'validateFields'> & {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type EventArgs = any[];
-
-type ValidateMessage = string | (() => string);
-export interface ValidateMessages {
-  default?: ValidateMessage;
-  required?: ValidateMessage;
-  enum?: ValidateMessage;
-  whitespace?: ValidateMessage;
-  date?: {
-    format?: ValidateMessage;
-    parse?: ValidateMessage;
-    invalid?: ValidateMessage;
-  };
-  types?: {
-    string?: ValidateMessage;
-    method?: ValidateMessage;
-    array?: ValidateMessage;
-    object?: ValidateMessage;
-    number?: ValidateMessage;
-    date?: ValidateMessage;
-    boolean?: ValidateMessage;
-    integer?: ValidateMessage;
-    float?: ValidateMessage;
-    regexp?: ValidateMessage;
-    email?: ValidateMessage;
-    url?: ValidateMessage;
-    hex?: ValidateMessage;
-  };
-  string?: {
-    len?: ValidateMessage;
-    min?: ValidateMessage;
-    max?: ValidateMessage;
-    range?: ValidateMessage;
-  };
-  number?: {
-    len?: ValidateMessage;
-    min?: ValidateMessage;
-    max?: ValidateMessage;
-    range?: ValidateMessage;
-  };
-  array?: {
-    len?: ValidateMessage;
-    min?: ValidateMessage;
-    max?: ValidateMessage;
-    range?: ValidateMessage;
-  };
-  pattern?: {
-    mismatch?: ValidateMessage;
-  };
-}

--- a/src/utils/validateUtil.ts
+++ b/src/utils/validateUtil.ts
@@ -124,11 +124,7 @@ export function validateRules(
 
       // Replace validator if needed
       if (originValidatorFunc) {
-        cloneRule.validator = (
-          rule: RuleObject,
-          val: StoreValue,
-          callback: (error?: string) => void,
-        ) => {
+        cloneRule.validator = (rule, val, callback) => {
           let hasPromise = false;
 
           // Wrap callback only accept when promise not provided


### PR DESCRIPTION
Type definitions have been included since [async-validator v3.2.0](https://github.com/yiminghe/async-validator/releases/tag/v3.2.0), and adapt to the new types (e.g. `any`, `fields`).