### PR TITLE
fix: scrollToFirstError dont work

### DIFF
--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -132,7 +132,7 @@ const Form: React.ForwardRefRenderFunction<FormInstance, FormProps> = (
     if(_getSortFields) {
       _getSortFields(childrenNode.filter(item=>(typeof item === 'object'&&item.props.name)).map(item=>item.props.name));
     }
-  },[_getSortFields, childrenNode.filter(item=>(typeof item === 'object'&&item.props.name)).map(item=>item.props.name).join('')])
+  },[_getSortFields])
 
   // Not use subscribe when using render props
   useSubscribe(!childrenRenderProps);

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -32,6 +32,7 @@ export interface FormProps<Values = any> extends BaseFormProps {
   onFinishFailed?: Callbacks<Values>['onFinishFailed'];
   validateTrigger?: string | string[] | false;
   preserve?: boolean;
+  _getSortFields?: (sortFields: string[]) => void
 }
 
 const Form: React.ForwardRefRenderFunction<FormInstance, FormProps> = (
@@ -49,6 +50,7 @@ const Form: React.ForwardRefRenderFunction<FormInstance, FormProps> = (
     onFieldsChange,
     onFinish,
     onFinishFailed,
+    _getSortFields,
     ...restProps
   }: FormProps,
   ref,
@@ -125,6 +127,12 @@ const Form: React.ForwardRefRenderFunction<FormInstance, FormProps> = (
   } else {
     childrenNode = children;
   }
+
+  React.useMemo(()=>{
+    if(_getSortFields) {
+      _getSortFields(childrenNode.filter(item=>(typeof item === 'object'&&item.props.name)).map(item=>item.props.name));
+    }
+  },[_getSortFields, childrenNode.filter(item=>(typeof item === 'object'&&item.props.name)).map(item=>item.props.name).join('')])
 
   // Not use subscribe when using render props
   useSubscribe(!childrenRenderProps);


### PR DESCRIPTION
https://github.com/react-component/field-form/pull/279..
加一个钩子能拿到排序的fieldname数组