### PR TITLE
fix: RecursivePartial recursion stopped on optional field

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -210,16 +210,15 @@ export interface InternalHooks {
   getInitialValue: (namePath: InternalNamePath) => StoreValue;
 }
 
-/** Only return partial when type is not any */
-type RecursivePartial<T> = T extends object
-  ? {
-      [P in keyof T]?: T[P] extends (infer U)[]
-        ? RecursivePartial<U>[]
-        : T[P] extends object
-        ? RecursivePartial<T[P]>
-        : T[P];
-    }
-  : any;
+type Primitive = number | string | boolean | bigint | symbol | undefined | null
+
+type RecursivePartial<T> = {
+  [P in keyof T]?: T[P] extends Primitive
+    ? T[P]
+    : T[P] extends (infer U)[]
+    ? RecursivePartial<U>[]
+    : RecursivePartial<T[P]>
+}
 
 export interface FormInstance<Values = any> {
   // Origin Form API


### PR DESCRIPTION
setFieldsValue didn't work well for object with optional fields.
Example
`const form={} as FormInstance<{foo?:{bar:{baz:number}}}>
form.setFieldsValue({foo:{bar:undefined}})` // Type 'undefined' is not assignable to type '{ baz: number; }'