### PR TITLE
feat(useWatch): notify watch in preserve mode

### DIFF
--- a/docs/examples/useWatch.tsx
+++ b/docs/examples/useWatch.tsx
@@ -13,6 +13,7 @@ type FieldType = {
   demo2?: string;
   id?: number;
   demo1?: { demo2?: { demo3?: { demo4?: string } } };
+  hidden?: string;
 };
 
 const Demo = React.memo(() => {
@@ -48,12 +49,13 @@ export default () => {
   const demo4 = Form.useWatch(['demo1', 'demo2', 'demo3', 'demo4'], form);
   const demo5 = Form.useWatch(['demo1', 'demo2', 'demo3', 'demo4', 'demo5'], form);
   const more = Form.useWatch(['age', 'name', 'gender'], form);
-  console.log('main watch', values, demo1, demo2, main, age, demo3, demo4, demo5, more);
+  const hidden = Form.useWatch(['hidden'], { form, preserve: true });
+  console.log('main watch', values, demo1, demo2, main, age, demo3, demo4, demo5, more, hidden);
   return (
     <>
       <Form
         form={form}
-        initialValues={{ id: 1, age: '10', name: 'default' }}
+        initialValues={{ id: 1, age: '10', name: 'default', hidden: 'here' }}
         onFinish={v => console.log('submit values', v)}
       >
         no render
@@ -115,6 +117,7 @@ export default () => {
       <button onClick={() => setVisible(c => !c)}>isShow name</button>
       <button onClick={() => setVisible3(c => !c)}>isShow initialValue</button>
       <button onClick={() => setVisible2(c => !c)}>isShow demo2</button>
+      <button onClick={() => form.setFieldsValue({ hidden: `${form.getFieldsValue(true).hidden || ''}1` })}>change hidden field</button>
     </>
   );
 };

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -193,7 +193,16 @@ export interface Callbacks<Values = any> {
   onFinishFailed?: (errorInfo: ValidateErrorEntity<Values>) => void;
 }
 
-export type WatchCallBack = (values: Store, namePathList: InternalNamePath[]) => void;
+export type WatchCallBack = (
+  values: Store,
+  allValues: Store,
+  namePathList: InternalNamePath[],
+) => void;
+
+export interface WatchOptions<Form extends FormInstance = FormInstance> {
+  form?: Form;
+  preserve?: boolean;
+}
 
 export interface InternalHooks {
   dispatch: (action: ReducerAction) => void;

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -200,9 +200,10 @@ export class FormStore {
     // No need to cost perf when nothing need to watch
     if (this.watchList.length) {
       const values = this.getFieldsValue();
+      const allValues = this.getFieldsValue(true);
 
       this.watchList.forEach(callback => {
-        callback(values, namePath);
+        callback(values, allValues, namePath);
       });
     }
   };
@@ -548,7 +549,7 @@ export class FormStore {
     const namePathList: InternalNamePath[] = [];
 
     fields.forEach((fieldData: FieldData) => {
-      const { name, errors, ...data } = fieldData;
+      const { name, ...data } = fieldData;
       const namePath = getNamePath(name);
       namePathList.push(namePath);
 

--- a/src/utils/typeUtil.ts
+++ b/src/utils/typeUtil.ts
@@ -1,7 +1,13 @@
+import type { FormInstance, InternalFormInstance } from '../interface';
+
 export function toArray<T>(value?: T | T[] | null): T[] {
   if (value === undefined || value === null) {
     return [];
   }
 
   return Array.isArray(value) ? value : [value];
+}
+
+export function isFormInstance<T>(form: T | FormInstance): form is FormInstance {
+  return form && !!(form as InternalFormInstance)._init;
 }

--- a/tests/useWatch.test.tsx
+++ b/tests/useWatch.test.tsx
@@ -407,4 +407,34 @@ describe('useWatch', () => {
     );
     errorSpy.mockRestore();
   });
+
+  it('useWatch with preserve option', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const Demo: React.FC = () => {
+      const [form] = Form.useForm();
+      const nameValuePreserve = Form.useWatch<string>('name', {
+        form,
+        preserve: true,
+      });
+      const nameValue = Form.useWatch<string>('name', form);
+      React.useEffect(() => {
+        console.log(nameValuePreserve, nameValue);
+      }, [nameValuePreserve, nameValue]);
+      return (
+        <div>
+          <Form form={form} initialValues={{ name: 'bamboo' }} />
+          <div className="values">{nameValuePreserve}</div>
+          <button className="test-btn" onClick={() => form.setFieldValue('name', 'light')} />
+        </div>
+      );
+    };
+    await act(async () => {
+      const { container } = render(<Demo />);
+      await timeout();
+      expect(logSpy).toHaveBeenCalledWith('bamboo', undefined); // initialValue
+      fireEvent.click(container.querySelector('.test-btn'));
+      await timeout();
+      expect(logSpy).toHaveBeenCalledWith('light', undefined); // after setFieldValue
+    });
+  });
 });


### PR DESCRIPTION
The existing prop `preserve` in `Form` is used to keep values even if the field is not rendered. However, it will not trigger the `watchList` because the `getFieldsValue` is called without `true` and will return only the visible fields.

`Form` 目前已有的 `preserve` 属性是用来在 field 没有被渲染的情况下依旧能获取值。但它不能触发 `watchList`，因为内部的 `getFieldsValue` 在不传 `true` 的情况下只会返回可见的 fields。