### PR TITLE
fix: Form.List nested not support `preserve=false`

### DIFF
--- a/src/List.tsx
+++ b/src/List.tsx
@@ -29,6 +29,9 @@ export interface ListProps {
     operations: ListOperations,
     meta: Meta,
   ) => JSX.Element | React.ReactNode;
+
+  /** @private Passed by Form.List props. Do not use since it will break by path check. */
+  isListField?: boolean;
 }
 
 const List: React.FunctionComponent<ListProps> = ({
@@ -37,6 +40,7 @@ const List: React.FunctionComponent<ListProps> = ({
   children,
   rules,
   validateTrigger,
+  isListField,
 }) => {
   const context = React.useContext(FieldContext);
   const keyRef = React.useRef({
@@ -87,6 +91,7 @@ const List: React.FunctionComponent<ListProps> = ({
           validateTrigger={validateTrigger}
           initialValue={initialValue}
           isList
+          isListField={isListField}
         >
           {({ value = [], onChange }, meta) => {
             const { getFieldValue } = context;

--- a/tests/preserve.test.tsx
+++ b/tests/preserve.test.tsx
@@ -403,4 +403,46 @@ describe('Form.Preserve', () => {
 
     expect(container.querySelector<HTMLInputElement>('input')?.value).toEqual('bamboo');
   });
+
+  it('nest Form.List should clear correctly', async () => {
+    const { container } = render(
+      <Form
+        preserve={false}
+        initialValues={{
+          parent: [[{ name: 'bamboo' }]],
+        }}
+      >
+        <Form.List name="parent">
+          {(fields, { remove }) => {
+            return fields.map(field => (
+              <div key={field.key}>
+                <button
+                  onClick={() => {
+                    remove(field.name);
+                  }}
+                />
+                <Form.List name={[field.name]}>
+                  {childFields =>
+                    childFields.map(childField => (
+                      <div key={childField.key}>
+                        <Form.Field {...childField} name={[childField.name, 'name']}>
+                          <input />
+                        </Form.Field>
+                      </div>
+                    ))
+                  }
+                </Form.List>
+              </div>
+            ));
+          }}
+        </Form.List>
+      </Form>,
+    );
+
+    expect(container.querySelector('input').value).toEqual('bamboo');
+
+    // Clean
+    fireEvent.click(container.querySelector('button'));
+    expect(container.querySelector('input')).toBeFalsy();
+  });
 });

--- a/tests/preserve.test.tsx
+++ b/tests/preserve.test.tsx
@@ -421,7 +421,7 @@ describe('Form.Preserve', () => {
                     remove(field.name);
                   }}
                 />
-                <Form.List name={[field.name]}>
+                <Form.List {...field} name={[field.name]}>
                   {childFields =>
                     childFields.map(childField => (
                       <div key={childField.key}>


### PR DESCRIPTION
Form.List 直接嵌套时由于 Form.List 自身不支持 `isListField` 属性导致删除时会错误还原，补上即可：

fix https://github.com/ant-design/ant-design/issues/41740