### PR TITLE
fix: validated should be reset when trigger reset event

### DIFF
--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -253,7 +253,7 @@ class Field extends React.Component<InternalFieldProps, FieldState> implements F
           // Clean up state
           this.touched = false;
           this.dirty = false;
-          this.validatePromise = null;
+          this.validatePromise = undefined;
           this.errors = EMPTY_ERRORS;
           this.warnings = EMPTY_ERRORS;
           this.triggerMetaEvent();

--- a/tests/validate.test.tsx
+++ b/tests/validate.test.tsx
@@ -797,14 +797,28 @@ describe('Form.Validate', () => {
 
   it('should trigger onFieldsChange 3 times', async () => {
     const onFieldsChange = jest.fn();
+    const onMetaChange = jest.fn();
 
-    const wrapper = mount(
-      <Form onFieldsChange={onFieldsChange}>
-        <InfoField name="test" rules={[{ required: true }]}>
-          <Input />
-        </InfoField>
-      </Form>,
-    );
+    const App = () => {
+      const ref = React.useRef(null);
+      return (
+        <Form ref={ref} onFieldsChange={onFieldsChange}>
+          <InfoField
+            name="test"
+            rules={[{ required: true }]}
+            onMetaChange={meta => {
+              onMetaChange(meta.validated);
+            }}
+          >
+            <Input />
+          </InfoField>
+          <button id="reset" type="reset">
+            reset
+          </button>
+        </Form>
+      );
+    };
+    const wrapper = mount(<App />);
 
     await changeValue(getField(wrapper, 'test'), '');
 
@@ -847,5 +861,10 @@ describe('Form.Validate', () => {
       ],
       expect.anything(),
     );
+    // should reset validated and validating when reset btn had been clicked
+    wrapper.find('#reset').simulate('reset');
+    await timeout();
+    expect(onMetaChange).toHaveBeenNthCalledWith(3, true);
+    expect(onMetaChange).toHaveBeenNthCalledWith(4, false);
   });
 });


### PR DESCRIPTION
- close https://github.com/ant-design/ant-design/issues/41966

之前我们是根据 validatePromise 是否为 null 来判断是否触发过校验的，但我们之前漏了重置的时候，把 validatePromise 设置为 undefined 了，导致重置后依然是 null, 所以导致点击重置之后校验的状态一直还保留着。
<img width="721" alt="image" src="https://user-images.githubusercontent.com/10286961/234012181-b63f86b1-a0b1-4e3d-a477-580d9e503727.png">
