### PR TITLE
fix: `setField` or `setFields` or `setFieldValue` should update field

### DIFF
--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -301,9 +301,8 @@ class Field extends React.Component<InternalFieldProps, FieldState> implements F
       }
 
       case 'setField': {
+        const { data } = info;
         if (namePathMatch) {
-          const { data } = info;
-
           if ('touched' in data) {
             this.touched = data.touched;
           }
@@ -320,6 +319,10 @@ class Field extends React.Component<InternalFieldProps, FieldState> implements F
 
           this.triggerMetaEvent();
 
+          this.reRender();
+          return;
+        } else if ('value' in data && containsNamePath(namePathList, namePath, true)) {
+          // Contains path with value should also check
           this.reRender();
           return;
         }

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -764,12 +764,9 @@ export class FormStore {
     const prevStore = this.store;
 
     if (store) {
-      console.log('Before:', this.store, store);
       const nextStore = merge(this.store, store);
-      console.log('After:', nextStore);
       this.updateStore(nextStore);
     }
-    console.log('After2:', this.store);
 
     this.notifyObservers(prevStore, null, {
       type: 'valueUpdate',

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -764,9 +764,12 @@ export class FormStore {
     const prevStore = this.store;
 
     if (store) {
+      console.log('Before:', this.store, store);
       const nextStore = merge(this.store, store);
+      console.log('After:', nextStore);
       this.updateStore(nextStore);
     }
+    console.log('After2:', this.store);
 
     this.notifyObservers(prevStore, null, {
       type: 'valueUpdate',

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -322,7 +322,6 @@ describe('Form.Basic', () => {
     // Not trigger
     fireEvent.submit(container.querySelector('form'));
     await timeout();
-    console.log(container.innerHTML);
     matchError(container, "'user' is required");
     expect(onFinish).not.toHaveBeenCalled();
     expect(onFinishFailed).toHaveBeenCalledWith({
@@ -904,8 +903,8 @@ describe('Form.Basic', () => {
         act(() => {
           callback(form.current!);
         });
+        expect(form.current.getFieldValue(['user', 'name'])).toBeFalsy();
         expect(container.querySelector('input').value).toBe('');
-        expect(form.current.getFieldsValue()).toEqual({ user: null });
       });
     }
 

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -883,4 +883,38 @@ describe('Form.Basic', () => {
 
     expect(onMetaChange).toHaveBeenCalledTimes(0);
   });
+
+  describe('set to null value', () => {
+    function test(name: string, callback: (form: FormInstance) => void) {
+      it(name, async () => {
+        const form = React.createRef<FormInstance>();
+
+        const { container } = render(
+          <div>
+            <Form ref={form}>
+              <InfoField name={['user', 'name']} initialValue="bamboo" />
+            </Form>
+          </div>,
+        );
+
+        expect(container.querySelector('input').value).toBe('bamboo');
+        expect(form.current.getFieldsValue()).toEqual({ user: { name: 'bamboo' } });
+
+        // Set it
+        act(() => {
+          callback(form.current!);
+        });
+        expect(container.querySelector('input').value).toBe('');
+        expect(form.current.getFieldsValue()).toEqual({ user: null });
+      });
+    }
+
+    test('by setFieldsValue', form => {
+      form.setFieldsValue({ user: null });
+    });
+
+    test('by setFieldValue', form => {
+      form.setFieldValue('user', null);
+    });
+  });
 });

--- a/tests/initialValue.test.tsx
+++ b/tests/initialValue.test.tsx
@@ -172,7 +172,6 @@ describe('Form.InitialValues', () => {
     console.log('Form Value:', refForm.getFieldsValue(true));
 
     fireEvent.click(container.querySelector('button'));
-    console.log(container.innerHTML);
 
     expect(container.querySelector<HTMLInputElement>('.first-name-input').value).toEqual('aaa');
   });


### PR DESCRIPTION
ref #45010

修复底层 `setFields` 不会触发子路径匹配更新的问题。