### PR TITLE
feat: add warning "cannot be a function" in getValueProps

### DIFF
--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -583,7 +583,7 @@ class Field extends React.Component<InternalFieldProps, FieldState> implements F
     // warning when prop value is function
     if (process.env.NODE_ENV !== 'production') {
       Object.keys(valueProps).forEach(key => {
-        warning(typeof valueProps[key] !== 'function', "It's not recommended to generate dynamic function prop by getValueProps. Please pass it to child component directly")
+        warning(typeof valueProps[key] !== 'function', `It's not recommended to generate dynamic function prop by getValueProps. Please pass it to child component directly (prop: ${key})`)
       })
     }
 

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -583,7 +583,7 @@ class Field extends React.Component<InternalFieldProps, FieldState> implements F
     // warning when prop value is function
     if (process.env.NODE_ENV !== 'production') {
       Object.keys(valueProps).forEach(key => {
-        warning(typeof valueProps[key] !== 'function', `It's not recommended to generate dynamic function prop by getValueProps. Please pass it to child component directly (prop: ${key})`)
+        warning(typeof valueProps[key] !== 'function', `It's not recommended to generate dynamic function prop by \`getValueProps\`. Please pass it to child component directly (prop: ${key})`)
       })
     }
 

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -583,7 +583,7 @@ class Field extends React.Component<InternalFieldProps, FieldState> implements F
     // warning when prop value is function
     if (process.env.NODE_ENV !== 'production') {
       Object.keys(valueProps).forEach(key => {
-        warning(typeof valueProps[key] !== 'function', `Not recommended return prop value is function in getValueProps (prop name: "${key}")`)
+        warning(typeof valueProps[key] !== 'function', "It's not recommended to generate dynamic function prop by getValueProps. Please pass it to child component directly")
       })
     }
 

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -59,8 +59,8 @@ export type MetaEvent = Meta & { destroy?: boolean };
 
 export interface InternalFieldProps<Values = any> {
   children?:
-    | React.ReactElement
-    | ((control: ChildProps, meta: Meta, form: FormInstance<Values>) => React.ReactNode);
+  | React.ReactElement
+  | ((control: ChildProps, meta: Meta, form: FormInstance<Values>) => React.ReactNode);
   /**
    * Set up `dependencies` field.
    * When dependencies field update and current field is touched,
@@ -581,9 +581,11 @@ class Field extends React.Component<InternalFieldProps, FieldState> implements F
     const valueProps = mergedGetValueProps(value);
 
     // warning when prop value is function
-    Object.keys(valueProps).forEach(key => {
-      warning(typeof valueProps[key] !== 'function', `cannot return prop value is function in getValueProps (prop name: "${key}")`)
-    })
+    if (process.env.NODE_ENV !== 'production') {
+      Object.keys(valueProps).forEach(key => {
+        warning(typeof valueProps[key] !== 'function', `Not recommended return prop value is function in getValueProps (prop name: "${key}")`)
+      })
+    }
 
     const control = {
       ...childProps,

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -578,9 +578,16 @@ class Field extends React.Component<InternalFieldProps, FieldState> implements F
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const originTriggerFunc: any = childProps[trigger];
 
+    const valueProps = mergedGetValueProps(value);
+
+    // warning when prop value is function
+    Object.keys(valueProps).forEach(key => {
+      warning(typeof valueProps[key] !== 'function', `cannot return prop value is function in getValueProps (prop name: "${key}")`)
+    })
+
     const control = {
       ...childProps,
-      ...mergedGetValueProps(value),
+      ...valueProps,
     };
 
     // Add trigger


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `master` branch.
Before submitting your pull request, please make sure the checklist below is confirmed.
Your pull requests will be merged after one of the collaborators approve.
Thank you!
-->

[[中文版模板 / Chinese template](https://github.com/ant-design/ant-design/blob/master/.github/PULL_REQUEST_TEMPLATE/pr_cn.md?plain=1)]

### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / documentation update
- [ ] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [x] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Workflow
- [ ] Other (about what?)

### 🔗 Related issue link

关联 PR https://github.com/ant-design/ant-design/pull/46445

关联 issue https://github.com/ant-design/ant-design/issues/46417


### 💡 Background and solution

根据 #46445  的改动为 getValueProps 的返回值加上一层 warning，判断返回值是否为 function 是 function 则给予提示

### 📝 Changelog

<!--
Describe changes from the user side, and list all potential break changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |     Add a prompt for the error message returned by the Field component's getValueProps      |
| 🇨🇳 Chinese |     为  Field 组件的 getValueProps  返回错误提示增加提示  |

### ☑️ Self-Check before Merge

⚠️ Please check all items below before requesting a reviewing. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
