### PR TITLE
fix: annotation with rollup conflict (#631)

### DIFF
--- a/src/utils/validateUtil.ts
+++ b/src/utils/validateUtil.ts
@@ -84,7 +84,7 @@ async function validateRule(
           // Annotation makes conflict with rollup
           // ref https://github.com/react-component/field-form/issues/631
           const key = `error_${index}`;
-          React.cloneElement(mergedMessage, { key });
+          return React.cloneElement(mergedMessage, { key });
         }
         return mergedMessage;
       });

--- a/src/utils/validateUtil.ts
+++ b/src/utils/validateUtil.ts
@@ -79,10 +79,14 @@ async function validateRule(
       result = errObj.errors.map(({ message }, index: number) => {
         const mergedMessage = message === CODE_LOGIC_ERROR ? messages.default : message;
 
-        return React.isValidElement(mergedMessage)
-          ? // Wrap ReactNode with `key`
-            React.cloneElement(mergedMessage, { key: `error_${index}` })
-          : mergedMessage;
+        if (React.isValidElement(mergedMessage)) {
+          // Wrap ReactNode with `key`
+          // Annotation makes conflict with rollup
+          // ref https://github.com/react-component/field-form/issues/631
+          const key = `error_${index}`;
+          React.cloneElement(mergedMessage, { key });
+        }
+        return mergedMessage;
       });
     }
   }


### PR DESCRIPTION
> `/*#__PURE__*/` 和函数调用之间只能有空格。

代码打包导致 `/*#__PURE__*/` 添加在注释的前面，不是函数调用的前面，导致在 rollup 中无效：

![无效的注释](https://github.com/react-component/field-form/assets/47056890/b66d6d43-5224-47fe-9ccf-57b89d884ae1)

更改代码注释的位置，能够得到有效的 `/*#__PURE__*/`：

![有效的注释](https://github.com/react-component/field-form/assets/47056890/5671434a-6854-4678-b919-97a14821ce39)


---

2024 年 01 月 16 日 14:01:46