### PR TITLE
fix: the name types of `FormInstance` are not inferred correctly

### DIFF
--- a/docs/examples/basic.tsx
+++ b/docs/examples/basic.tsx
@@ -9,7 +9,7 @@ type FormData = {
 };
 
 export default () => {
-  const [form] = Form.useForm();
+  const [form] = Form.useForm<FormData>();
 
   return (
     <Form

--- a/docs/examples/initialValues.tsx
+++ b/docs/examples/initialValues.tsx
@@ -12,7 +12,7 @@ const formValue = {
 };
 
 export default () => {
-  const [form] = Form.useForm();
+  const [form] = Form.useForm<typeof formValue>();
   const [show, setShow] = useState<boolean>(false);
 
   return (

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -24,8 +24,8 @@ export interface InternalFieldData extends Meta {
 /**
  * Used by `setFields` config
  */
-export interface FieldData extends Partial<Omit<InternalFieldData, 'name'>> {
-  name: NamePath;
+export interface FieldData<Values = any> extends Partial<Omit<InternalFieldData, 'name'>> {
+  name: NamePath<Values>;
 }
 
 export type RuleType =
@@ -251,21 +251,21 @@ export type GetFieldsValueConfig = { strict?: boolean; filter?: FilterFunc };
 
 export interface FormInstance<Values = any> {
   // Origin Form API
-  getFieldValue: (name: NamePath) => StoreValue;
+  getFieldValue: (name: NamePath<Values>) => StoreValue;
   getFieldsValue: (() => Values) &
-    ((nameList: NamePath[] | true, filterFunc?: FilterFunc) => any) &
+    ((nameList: NamePath<Values>[] | true, filterFunc?: FilterFunc) => any) &
     ((config: GetFieldsValueConfig) => any);
-  getFieldError: (name: NamePath) => string[];
-  getFieldsError: (nameList?: NamePath[]) => FieldError[];
-  getFieldWarning: (name: NamePath) => string[];
-  isFieldsTouched: ((nameList?: NamePath[], allFieldsTouched?: boolean) => boolean) &
+  getFieldError: (name: NamePath<Values>) => string[];
+  getFieldsError: (nameList?: NamePath<Values>[]) => FieldError[];
+  getFieldWarning: (name: NamePath<Values>) => string[];
+  isFieldsTouched: ((nameList?: NamePath<Values>[], allFieldsTouched?: boolean) => boolean) &
     ((allFieldsTouched?: boolean) => boolean);
-  isFieldTouched: (name: NamePath) => boolean;
-  isFieldValidating: (name: NamePath) => boolean;
-  isFieldsValidating: (nameList?: NamePath[]) => boolean;
-  resetFields: (fields?: NamePath[]) => void;
-  setFields: (fields: FieldData[]) => void;
-  setFieldValue: (name: NamePath, value: any) => void;
+  isFieldTouched: (name: NamePath<Values>) => boolean;
+  isFieldValidating: (name: NamePath<Values>) => boolean;
+  isFieldsValidating: (nameList?: NamePath<Values>[]) => boolean;
+  resetFields: (fields?: NamePath<Values>[]) => void;
+  setFields: (fields: FieldData<Values>[]) => void;
+  setFieldValue: (name: NamePath<Values>, value: any) => void;
   setFieldsValue: (values: RecursivePartial<Values>) => void;
   validateFields: ValidateFields<Values>;
 


### PR DESCRIPTION
| Before | After |
| ------ | ------|
| <img width="911" alt="image" src="https://github.com/react-component/field-form/assets/48519459/c4276a6c-3b0a-42d3-939b-ee37b85ff2b1"> | <img width="1334" alt="image" src="https://github.com/react-component/field-form/assets/48519459/46233efe-e386-4f9a-94ae-572359eb4883"> |
| <img width="973" alt="image" src="https://github.com/react-component/field-form/assets/48519459/8528ce38-ae79-4ee6-a2d3-499907b8c31b"> |<img width="1401" alt="image" src="https://github.com/react-component/field-form/assets/48519459/7366844c-cea3-47a2-b603-144af82ec35a"> |
| <img width="514" alt="image" src="https://github.com/react-component/field-form/assets/48519459/0973e7c0-022c-41dd-8259-dc026a0f51f1"> | <img width="1253" alt="image" src="https://github.com/react-component/field-form/assets/48519459/92f53a5e-bb23-4812-b682-d702f3180888"> |