### PR TITLE
fix: `getValueProps` should not be executed when `name` does not exist

### DIFF
--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -583,7 +583,7 @@ class Field extends React.Component<InternalFieldProps, FieldState> implements F
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const originTriggerFunc: any = childProps[trigger];
 
-    const valueProps = Array.isArray(name) ? mergedGetValueProps(value) : {};
+    const valueProps = name !== undefined ? mergedGetValueProps(value) : {};
 
     // warning when prop value is function
     if (process.env.NODE_ENV !== 'production' && valueProps) {

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -583,7 +583,7 @@ class Field extends React.Component<InternalFieldProps, FieldState> implements F
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const originTriggerFunc: any = childProps[trigger];
 
-    const valueProps = name ? mergedGetValueProps(value) : {};
+    const valueProps = Array.isArray(name) ? mergedGetValueProps(value) : {};
 
     // warning when prop value is function
     if (process.env.NODE_ENV !== 'production' && valueProps) {

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -561,6 +561,7 @@ class Field extends React.Component<InternalFieldProps, FieldState> implements F
 
   public getControlled = (childProps: ChildProps = {}) => {
     const {
+      name,
       trigger,
       validateTrigger,
       getValueFromEvent,
@@ -582,7 +583,7 @@ class Field extends React.Component<InternalFieldProps, FieldState> implements F
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const originTriggerFunc: any = childProps[trigger];
 
-    const valueProps = mergedGetValueProps(value);
+    const valueProps = name ? mergedGetValueProps(value) : {};
 
     // warning when prop value is function
     if (process.env.NODE_ENV !== 'production' && valueProps) {

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -413,19 +413,24 @@ describe('Form.Basic', () => {
   });
 
   it('getValueProps should not be executed when name does not exist', async () => {
-    const getValueProps = jest.fn();
+    const getValueProps1 = jest.fn();
+    const getValueProps2 = jest.fn();
 
     render(
       <div>
         <Form initialValues={{ test: 'bamboo' }}>
-          <Field getValueProps={getValueProps}>
+          <Field getValueProps={getValueProps1}>
             <span className="anything" />
+          </Field>
+          <Field getValueProps={getValueProps2}>
+            {() => <span className="anything" />}
           </Field>
         </Form>
       </div>,
     );
 
-    expect(getValueProps).not.toHaveBeenCalled();
+    expect(getValueProps1).not.toHaveBeenCalled();
+    expect(getValueProps2).not.toHaveBeenCalled();
   });
 
   describe('shouldUpdate', () => {

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -412,6 +412,22 @@ describe('Form.Basic', () => {
     expect(container.querySelector('.anything')).toBeTruthy();
   });
 
+  it('getValueProps should not be executed when name does not exist', async () => {
+    const getValueProps = jest.fn();
+
+    render(
+      <div>
+        <Form initialValues={{ test: 'bamboo' }}>
+          <Field getValueProps={getValueProps}>
+            <span className="anything" />
+          </Field>
+        </Form>
+      </div>,
+    );
+
+    expect(getValueProps).not.toHaveBeenCalled();
+  });
+
   describe('shouldUpdate', () => {
     it('work', async () => {
       let isAllTouched: boolean;


### PR DESCRIPTION
ref: [ant-design/ant-design#47952](https://github.com/ant-design/ant-design/issues/47952)