### PR TITLE
Fix replaceMessage function to handle escaped variables

### DIFF
--- a/src/utils/validateUtil.ts
+++ b/src/utils/validateUtil.ts
@@ -19,7 +19,10 @@ const AsyncValidator: any = RawAsyncValidator;
  *   `I'm ${name}` + { name: 'bamboo' } = I'm bamboo
  */
 function replaceMessage(template: string, kv: Record<string, string>): string {
-  return template.replace(/\$\{\w+\}/g, (str: string) => {
+  return template.replace(/\\?\$\{\w+\}/g, (str: string) => {
+    if (str.startsWith('\\')) {
+      return str.slice(1);
+    }
     const key = str.slice(2, -1);
     return kv[key];
   });
@@ -79,7 +82,7 @@ async function validateRule(
       result = errObj.errors.map(({ message }, index: number) => {
         const mergedMessage = message === CODE_LOGIC_ERROR ? messages.default : message;
 
-        return React.isValidElement(mergedMessage)
+        return React.isValidElement(ergedMessage)
           ? // Wrap ReactNode with `key`
             React.cloneElement(mergedMessage, { key: `error_${index}` })
           : mergedMessage;

--- a/src/utils/validateUtil.ts
+++ b/src/utils/validateUtil.ts
@@ -82,7 +82,7 @@ async function validateRule(
       result = errObj.errors.map(({ message }, index: number) => {
         const mergedMessage = message === CODE_LOGIC_ERROR ? messages.default : message;
 
-        return React.isValidElement(ergedMessage)
+        return React.isValidElement(mergedMessage)
           ? // Wrap ReactNode with `key`
             React.cloneElement(mergedMessage, { key: `error_${index}` })
           : mergedMessage;

--- a/tests/validate.test.tsx
+++ b/tests/validate.test.tsx
@@ -1045,7 +1045,7 @@ describe('Form.Validate', () => {
         <InfoField name="noop" rules={[{ required: true, message: 'noop' }]}>
           <Input />
         </InfoField>
-      </Form>
+      </Form>,
     );
 
     const { container, rerender } = render(
@@ -1080,5 +1080,42 @@ describe('Form.Validate', () => {
     matchError(container.querySelectorAll<HTMLDivElement>('.field')[2], false);
 
     jest.useRealTimers();
+  });
+
+  it('should handle escaped and unescaped variables correctly', async () => {
+    const { container } = render(
+      <Form>
+        <InfoField
+          name="test"
+          rules={[
+            {
+              validator: async (_, value) => {
+                if (value !== 'bamboo') {
+                  return Promise.reject(new Error('should be ${name}!'));
+                }
+                return '';
+              },
+              messageVariables: {
+                name: 'bamboo',
+              },
+            },
+          ]}
+        >
+          <Input />
+        </InfoField>
+      </Form>,
+    );
+
+    // Wrong value
+    await changeValue(getInput(container), 'light');
+    matchError(container, 'should be bamboo!');
+
+    // Correct value
+    await changeValue(getInput(container), 'bamboo');
+    matchError(container, false);
+
+    // Escaped variable
+    await changeValue(getInput(container), 'should be ${name}!');
+    matchError(container, 'should be ${name}!');
   });
 });

--- a/tests/validate.test.tsx
+++ b/tests/validate.test.tsx
@@ -1045,7 +1045,7 @@ describe('Form.Validate', () => {
         <InfoField name="noop" rules={[{ required: true, message: 'noop' }]}>
           <Input />
         </InfoField>
-      </Form>,
+      </Form>
     );
 
     const { container, rerender } = render(
@@ -1086,18 +1086,13 @@ describe('Form.Validate', () => {
     const { container } = render(
       <Form>
         <InfoField
+          messageVariables={{
+            name: 'bamboo',
+          }}
           name="test"
           rules={[
             {
-              validator: async (_, value) => {
-                if (value !== 'bamboo') {
-                  return Promise.reject(new Error('should be ${name}!'));
-                }
-                return '';
-              },
-              messageVariables: {
-                name: 'bamboo',
-              },
+              validator: () => Promise.reject(new Error('\\${name} should be ${name}!')),
             },
           ]}
         >
@@ -1108,14 +1103,6 @@ describe('Form.Validate', () => {
 
     // Wrong value
     await changeValue(getInput(container), 'light');
-    matchError(container, 'should be bamboo!');
-
-    // Correct value
-    await changeValue(getInput(container), 'bamboo');
-    matchError(container, false);
-
-    // Escaped variable
-    await changeValue(getInput(container), 'should be ${name}!');
-    matchError(container, 'should be ${name}!');
+    matchError(container, '${name} should be bamboo!');
   });
 });


### PR DESCRIPTION
Modify the `replaceMessage` function in `src/utils/validateUtil.ts` to handle escaped variables and add related test cases.

* **replaceMessage function**:
  - Update the `replaceMessage` function to skip conversion when `\${xxx}` is passed and convert `${xxx}` correctly.
  - Check for the presence of `\${xxx}` and skip conversion in such cases.
  - Ensure the function correctly converts `${xxx}` to the corresponding value from the `kv` object.

* **validate.test.tsx**:
  - Add test cases to verify the correct handling of `\${xxx}` and `${xxx}`.
  - Ensure the test cases cover both scenarios: skipping conversion and converting correctly.
  - Add a new test case to handle escaped and unescaped variables correctly.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/react-component/field-form?shareId=91e181af-544b-4502-8294-e543c5e5d7a8).