### PR TITLE
修复”RangePicker组件在onCalendarChange方法中调用form.setFieldsValue会导致时间不可选择”的问题

### DIFF
--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -46,7 +46,8 @@ function requireUpdate(
   if (typeof shouldUpdate === 'function') {
     return shouldUpdate(prev, next, 'source' in info ? { source: info.source } : {});
   }
-  return prevValue !== nextValue;
+  // return prevValue !== nextValue;
+  return !isEqual(prev, next)
 }
 
 // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style


### PR DESCRIPTION
antd-design有一个”[RangePicker组件在onCalendarChange方法中调用form.setFieldsValue会导致时间不可选择](https://github.com/ant-design/ant-design/issues/49470)”问题，进排查，定位到底层依赖组件field-form的问题，已修复