### PR TITLE
fix: change not trigger on Date

### DIFF
--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -620,7 +620,7 @@ class Field extends React.Component<InternalFieldProps, FieldState> implements F
       if (normalize) {
         newValue = normalize(newValue, value, getFieldsValue(true));
       }
-      if (!isEqual(newValue, value)) {
+      if (newValue !== value) {
         dispatch({
           type: 'updateValue',
           namePath,

--- a/tests/control.test.tsx
+++ b/tests/control.test.tsx
@@ -40,18 +40,4 @@ describe('Form.Control', () => {
     await changeValue(getInput(container), ['bamboo', '']);
     matchError(container, "'test' is required");
   });
-
-  it('value no change', async () => {
-    const fn = jest.fn();
-    const { container } = render(
-      <Form onFieldsChange={fn}>
-        <InfoField name="test" normalize={value => value?.replace(/\D/g, '') || undefined} />
-      </Form>,
-    );
-
-    await changeValue(getInput(container), 'bamboo');
-    expect(fn).toHaveBeenCalledTimes(0);
-    await changeValue(getInput(container), '1');
-    expect(fn).toHaveBeenCalledTimes(1);
-  });
 });

--- a/tests/field.test.tsx
+++ b/tests/field.test.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import Form, { Field } from '../src';
 import type { FormInstance } from '../src';
-import { render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
+import { Input } from './common/InfoField';
+import { getInput } from './common';
+import timeout from './common/timeout';
 
 describe('Form.Field', () => {
   it('field remount should trigger constructor again', () => {
@@ -36,5 +39,38 @@ describe('Form.Field', () => {
     // expect(instance.cancelRegisterFunc).toBeFalsy();
     // expect((wrapper.find('Field').instance() as any).cancelRegisterFunc).toBeTruthy();
     expect(formRef.getFieldsValue()).toEqual({ light: 'bamboo' });
+  });
+
+  // https://github.com/ant-design/ant-design/issues/51611
+  it('date type as change', async () => {
+    const onValuesChange = jest.fn();
+
+    const MockDateInput = (props: { onChange?: (val: Date) => void }) => (
+      <button
+        onClick={() => {
+          props.onChange?.(new Date());
+        }}
+      >
+        Mock
+      </button>
+    );
+
+    const { container } = render(
+      <Form onValuesChange={onValuesChange}>
+        <Field name="date">
+          <MockDateInput />
+        </Field>
+      </Form>,
+    );
+
+    // Trigger
+    for (let i = 0; i < 3; i += 1) {
+      fireEvent.click(container.querySelector('button'));
+      await act(async () => {
+        await timeout();
+      });
+      expect(onValuesChange).toHaveBeenCalled();
+      onValuesChange.mockReset();
+    }
   });
 });

--- a/tests/legacy/field-props.test.tsx
+++ b/tests/legacy/field-props.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { FormInstance } from '../../src';
 import Form, { Field } from '../../src';
-import { Input } from '../common/InfoField';
+import InfoField, { Input } from '../common/InfoField';
 import { changeValue, getInput, matchArray } from '../common';
 import { render } from '@testing-library/react';
 
@@ -55,22 +55,38 @@ describe('legacy.field-props', () => {
     expect(form.current?.getFieldValue('normal')).toBe('21');
   });
 
-  it('normalize', async () => {
-    const form = React.createRef<FormInstance>();
-    const { container } = render(
-      <div>
-        <Form ref={form}>
-          <Field name="normal" normalize={v => v && v.toUpperCase()}>
-            <Input />
-          </Field>
-        </Form>
-      </div>,
-    );
+  describe('normalize', () => {
+    it('basic', async () => {
+      const form = React.createRef<FormInstance>();
+      const { container } = render(
+        <div>
+          <Form ref={form}>
+            <Field name="normal" normalize={v => v && v.toUpperCase()}>
+              <Input />
+            </Field>
+          </Form>
+        </div>,
+      );
 
-    await changeValue(getInput(container), 'a');
+      await changeValue(getInput(container), 'a');
 
-    expect(form.current?.getFieldValue('normal')).toBe('A');
-    expect(getInput(container).value).toBe('A');
+      expect(form.current?.getFieldValue('normal')).toBe('A');
+      expect(getInput(container).value).toBe('A');
+    });
+
+    it('value no change', async () => {
+      const fn = jest.fn();
+      const { container } = render(
+        <Form onFieldsChange={fn}>
+          <InfoField name="test" normalize={value => value?.replace(/\D/g, '') || undefined} />
+        </Form>,
+      );
+
+      await changeValue(getInput(container), 'bamboo');
+      expect(fn).toHaveBeenCalledTimes(0);
+      await changeValue(getInput(container), '1');
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('support jsx message', async () => {


### PR DESCRIPTION
Date 对象的数据在闭包里，equals 无法检测降级一下：

fix https://github.com/ant-design/ant-design/issues/51611

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 更新了 `Field` 组件的值比较逻辑，简化了值更新的触发条件。
  
- **错误修复**
  - 移除了不必要的测试用例，确保只有在输入值发生变化时才触发回调。

- **文档**
  - 更新了测试用例的组织结构和注释，提升了可读性和清晰度。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->