### PR TITLE
fix: List nest Field should correct removed

### DIFF
--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -689,7 +689,7 @@ function WrapperField<Values = any>({ name, ...restProps }: FieldProps<Values>) 
   const listContext = React.useContext(ListContext);
   const namePath = name !== undefined ? getNamePath(name) : undefined;
 
-  const isMergedListField = !!listContext || restProps.isList;
+  const isMergedListField = restProps.isListField ?? !!listContext;
 
   let key: string = 'keep';
   if (!isMergedListField) {
@@ -701,7 +701,7 @@ function WrapperField<Values = any>({ name, ...restProps }: FieldProps<Values>) 
   if (
     process.env.NODE_ENV !== 'production' &&
     restProps.preserve === false &&
-    isMergedListField &&
+    restProps.isListField &&
     namePath.length <= 1
   ) {
     warning(false, '`preserve` should not apply on Form.List fields.');

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -701,7 +701,7 @@ function WrapperField<Values = any>({ name, ...restProps }: FieldProps<Values>) 
   if (
     process.env.NODE_ENV !== 'production' &&
     restProps.preserve === false &&
-    restProps.isListField &&
+    isMergedListField &&
     namePath.length <= 1
   ) {
     warning(false, '`preserve` should not apply on Form.List fields.');

--- a/src/Field.tsx
+++ b/src/Field.tsx
@@ -689,8 +689,10 @@ function WrapperField<Values = any>({ name, ...restProps }: FieldProps<Values>) 
   const listContext = React.useContext(ListContext);
   const namePath = name !== undefined ? getNamePath(name) : undefined;
 
+  const isMergedListField = !!listContext || restProps.isList;
+
   let key: string = 'keep';
-  if (!restProps.isListField) {
+  if (!isMergedListField) {
     key = `_${(namePath || []).join('_')}`;
   }
 
@@ -699,7 +701,7 @@ function WrapperField<Values = any>({ name, ...restProps }: FieldProps<Values>) 
   if (
     process.env.NODE_ENV !== 'production' &&
     restProps.preserve === false &&
-    restProps.isListField &&
+    isMergedListField &&
     namePath.length <= 1
   ) {
     warning(false, '`preserve` should not apply on Form.List fields.');
@@ -709,7 +711,7 @@ function WrapperField<Values = any>({ name, ...restProps }: FieldProps<Values>) 
     <Field
       key={key}
       name={namePath}
-      isListField={!!listContext}
+      isListField={isMergedListField}
       {...restProps}
       fieldContext={fieldContext}
     />

--- a/tests/list.test.tsx
+++ b/tests/list.test.tsx
@@ -935,6 +935,6 @@ describe('Form.List', () => {
       await timeout();
     });
 
-    console.log(formRef.current!.getFieldValue('list'));
+    expect(formRef.current!.getFieldValue('list')).toEqual([{ user: '1' }, { user: '3' }]);
   });
 });


### PR DESCRIPTION
ref https://github.com/ant-design/ant-design/issues/51702

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 改进了 `Field` 组件对列表字段的处理，确保上下文正确合并并发出适当的警告。
- **错误修复**
	- 增强了测试套件，确保在各种操作（如添加、删除和修改字段）中，表单状态保持一致。
	- 添加了新测试，验证在 `preserve` 属性设置为 `false` 时嵌套字段的行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->