### PR TITLE
feat(validateFields): add message to reject error type

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -86,6 +86,7 @@ export type RuleObject = AggregationRule | ArrayRule;
 export type Rule = RuleObject | RuleRender;
 
 export interface ValidateErrorEntity<Values = any> {
+  message: string;
   values: Values;
   errorFields: { name: InternalNamePath; errors: string[] }[];
   outOfDate: boolean;

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -982,7 +982,9 @@ export class FormStore {
       })
       .catch((results: { name: InternalNamePath; errors: string[] }[]) => {
         const errorList = results.filter(result => result && result.errors.length);
+        const errorMessage = errorList[0]?.errors?.[0];
         return Promise.reject({
+          message: errorMessage,
           values: this.getFieldsValue(namePathList),
           errorFields: errorList,
           outOfDate: this.lastValidatePromise !== summaryPromise,

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -328,9 +328,12 @@ describe('Form.Basic', () => {
     matchError(container, "'user' is required");
     expect(onFinish).not.toHaveBeenCalled();
     expect(onFinishFailed).toHaveBeenCalledWith({
+      message: "'user' is required",
       errorFields: [{ name: ['user'], errors: ["'user' is required"], warnings: [] }],
       outOfDate: false,
-      values: {},
+      values: {
+        user: undefined
+      },
     });
 
     onFinish.mockReset();


### PR DESCRIPTION
在日常开发中，有时会使用链式 promise 调用：

```js
form
  .validateFields()
  .then(values => axios.post('url', values))
  .then(...)
  .catch(err => message.error(err.message))
```

但是当表单校验失败时，弹出的 message 是空的，因为 validateFields 的 reject 返回并非标准 Error 对象，没有 message 属性。

此 PR 为 validateFields 的 reject 返回增加 message，使其更像一个 Error 对象。在需要展示 popup message 的场景能够更便捷的取值。降低开发者学习和使用的成本。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 扩展了验证错误实体接口，增加了错误消息属性。

- **Bug 修复**
	- 改进了表单验证错误处理机制，现在可以返回第一个错误消息。
	- 测试用例中增加了对表单提交失败的错误处理，明确显示缺少必填字段时的错误消息。

这些更改旨在提供更详细和清晰的验证错误信息，帮助用户更好地理解和解决表单验证问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->