### PR TITLE
fix: Avoid exponential loops when a large number of components are un…

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -682,7 +682,10 @@ export class FormStore {
         }
       }
 
-      this.notifyWatch([namePath]);
+      // Avoid exponential loops when a large number of components are unloaded
+      setTimeout(() => {
+        this.notifyWatch([namePath]);
+      })
     };
   };
 


### PR DESCRIPTION
I have a demo ready for you  https://codesandbox.io/p/sandbox/rt8qcf

当有useWatch存在时，有大量的Field组件被卸载时，会导致react在commit阶段调用componentWillUnmount, 导致调用registerField的返回函数（在useWatch中是叫cancelRegister），然后调用notifyWatch，notifyWatch又会去调用this.getFieldsValue()， this.getFieldsValue()会去循环所有挂载的组件，就会导致循环指数增长，如果有50个组件就会有 (49+1)*49/2 = 1225 次循环，如果有1000个组件就会有 （999+1）* 999 / 2 = 499500 次循环，如果给notifyWatch增加promise.then或者setTimeout就可以解决这个问题，延迟执行后，已经卸载的组件就不会再出现在fieldEntities中，减少大量循环，且该commit对功能无影响

When a large number of Field components are unmounted, it will cause react to call componentWillUnmount during the commit phase, resulting in the call of the return function of registerField (called cancelRegister in useWatch). Then call 'notifyWatch', and 'notifyWatch' will call 'this.getFieldsValue()'. 'this.getFieldsValue()' will loop through all mounted components, which will cause the loop to grow exponentially. If there are 50 components, there will be (49+1)*49/2 = 1225 loops. If there are 1000 components, there will be (999+1)* 999/2 = 499,500 loops. If promise.then or setTimeout is added to notifyWatch, this problem can be solved. After the delayed execution, the uninstalled components will no longer appear in fieldEntities, reducing a large number of loops, and this commit has no impact on the functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 优化了表单字段注销时的通知机制，避免在大量组件同时卸载时出现性能问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->