### PR TITLE
fix: setFieldValue should be touched

### DIFF
--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -812,6 +812,7 @@ export class FormStore {
         value,
         errors: [],
         warnings: [],
+        touched: true,
       },
     ]);
   };

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -885,6 +885,10 @@ describe('Form.Basic', () => {
       Array.from(container.querySelectorAll<HTMLInputElement>('input')).map(input => input?.value),
     ).toEqual(['bamboo', 'little', 'light', 'nested']);
 
+    // Check initial touched state
+    expect(formRef.current.isFieldTouched(['list', 1])).toBeFalsy();
+    expect(formRef.current.isFieldTouched(['nest', 'target'])).toBeFalsy();
+
     // Set
     act(() => {
       formRef.current.setFieldValue(['list', 1], 'tiny');
@@ -894,6 +898,15 @@ describe('Form.Basic', () => {
     expect(
       Array.from(container.querySelectorAll<HTMLInputElement>('input')).map(input => input?.value),
     ).toEqual(['bamboo', 'tiny', 'light', 'match']);
+
+    // Check that setFieldValue DOES set touched to true
+    // (setFieldValue internally calls setFields with touched: true)
+    expect(formRef.current.isFieldTouched(['list', 1])).toBeTruthy();
+    expect(formRef.current.isFieldTouched(['nest', 'target'])).toBeTruthy();
+    
+    // Verify other fields remain untouched
+    expect(formRef.current.isFieldTouched(['list', 0])).toBeFalsy();
+    expect(formRef.current.isFieldTouched(['list', 2])).toBeFalsy();
   });
 
   it('onMetaChange should only trigger when meta changed', () => {


### PR DESCRIPTION
close #752
fix https://github.com/ant-design/ant-design/issues/53981

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 当通过表单方法设置字段值时，该字段会自动标记为已触碰（touched）。
* **测试**
  * 增强了相关测试用例，验证设置字段值后字段的触碰状态变化是否符合预期。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->