### PR TITLE
fix: Validate Error when value undefined

### DIFF
--- a/src/utils/validateUtil.ts
+++ b/src/utils/validateUtil.ts
@@ -90,7 +90,7 @@ async function validateRule(
     }
   }
 
-  if (!result.length && subRuleField) {
+  if (!result.length && subRuleField && Array.isArray(value) && value.length > 0) {
     const subResults: string[][] = await Promise.all(
       (value as StoreValue[]).map((subValue: StoreValue, i: number) =>
         validateRule(`${name}.${i}`, subValue, subRuleField, options, messageVariables),


### PR DESCRIPTION
fix: https://github.com/ant-design/ant-design/issues/55489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 优化数组验证逻辑：仅当数据为非空数组时才执行递归子规则验证，避免了不必要或无效的递归调用，提升验证性能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->