### PR TITLE
fix: preserve sibling values when nested list changes

### DIFF
--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -1,5 +1,4 @@
 import { merge } from '@rc-component/util/lib/utils/set';
-import { mergeWith } from '@rc-component/util';
 import warning from '@rc-component/util/lib/warning';
 import * as React from 'react';
 import { HOOK_MARK } from '../FieldContext';
@@ -779,14 +778,9 @@ export class FormStore {
     const { onValuesChange } = this.callbacks;
 
     if (onValuesChange) {
-      const fieldEntity = this.getFieldsMap(true).get(namePath);
       const changedValues = cloneByNamePathList(this.store, [namePath]);
       const allValues = this.getFieldsValue();
-      // Merge changedValues into allValues to ensure allValues contains the latest changes
-      const mergedAllValues = mergeWith([allValues, changedValues], {
-        // When value is array, it means trigger by Form.List which should replace directly
-        prepareArray: current => (fieldEntity?.isList() ? [] : [...(current || [])]),
-      });
+      const mergedAllValues = setValue(allValues, namePath, getValue(changedValues, namePath));
       onValuesChange(changedValues, mergedAllValues);
     }
 

--- a/tests/dependencies.test.tsx
+++ b/tests/dependencies.test.tsx
@@ -347,4 +347,49 @@ describe('Form.Dependencies', () => {
       { rules: [{ name: 'test', triggers: ['trigger_1'] }] },
     );
   });
+
+  it('mixed field list remove should not missing value with onValuesChange', () => {
+    const onValuesChange = jest.fn();
+
+    const { container } = render(
+      <Form
+        initialValues={{ rules: [{ name: 'test', triggers: ['trigger_1', 'trigger_2'] }] }}
+        onValuesChange={onValuesChange}
+      >
+        <Form.List name="rules">
+          {fields =>
+            fields.map(field => (
+              <div key={field.key}>
+                <Field {...field} name={[field.name, 'name']}>
+                  <Input />
+                </Field>
+
+                <Form.List name={[field.name, 'triggers']}>
+                  {(triggerFields, { remove }) => (
+                    <>
+                      {triggerFields.map(triggerField => (
+                        <Field {...triggerField} key={triggerField.key}>
+                          <Input />
+                        </Field>
+                      ))}
+                      <button type="button" onClick={() => remove(0)}>
+                        Remove trigger
+                      </button>
+                    </>
+                  )}
+                </Form.List>
+              </div>
+            ))
+          }
+        </Form.List>
+      </Form>,
+    );
+
+    fireEvent.click(container.querySelector('button')!);
+
+    expect(onValuesChange).toHaveBeenLastCalledWith(
+      expect.anything(),
+      { rules: [{ name: 'test', triggers: ['trigger_2'] }] },
+    );
+  });
 });

--- a/tests/dependencies.test.tsx
+++ b/tests/dependencies.test.tsx
@@ -302,4 +302,49 @@ describe('Form.Dependencies', () => {
     await changeValue(getInput(container), '1');
     matchError(container, false);
   });
+
+  it('mixed field list should not missing value with onValuesChange', () => {
+    const onValuesChange = jest.fn();
+
+    const { container } = render(
+      <Form
+        initialValues={{ rules: [{ name: 'test', triggers: [] }] }}
+        onValuesChange={onValuesChange}
+      >
+        <Form.List name="rules">
+          {fields =>
+            fields.map(field => (
+              <div key={field.key}>
+                <Field {...field} name={[field.name, 'name']}>
+                  <Input />
+                </Field>
+
+                <Form.List name={[field.name, 'triggers']}>
+                  {(triggerFields, { add }) => (
+                    <>
+                      {triggerFields.map(triggerField => (
+                        <Field {...triggerField} key={triggerField.key}>
+                          <Input />
+                        </Field>
+                      ))}
+                      <button type="button" onClick={() => add('trigger_1')}>
+                        Add trigger
+                      </button>
+                    </>
+                  )}
+                </Form.List>
+              </div>
+            ))
+          }
+        </Form.List>
+      </Form>,
+    );
+
+    fireEvent.click(container.querySelector('button')!);
+
+    expect(onValuesChange).toHaveBeenLastCalledWith(
+      expect.anything(),
+      { rules: [{ name: 'test', triggers: ['trigger_1'] }] },
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add a regression test for nested list updates via `onValuesChange`
- preserve sibling field values when a nested `Form.List` updates
- replace merge-based all-values reconstruction with a direct path update

## Testing
- npm test -- --runInBand tests/dependencies.test.tsx -t "mixed field list should not missing value with onValuesChange"
- npm test -- --runInBand tests/list.test.tsx -t "onValuesChange|array-valued fields|drop list items"
- npm test -- --runInBand tests/index.test.tsx -t "onValuesChange"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进了表单中嵌套列表字段的值更新逻辑，添加或移除嵌套项时，表单值变更回调能够正确反映该项的增删且保留父对象其他字段。
* **测试**
  * 新增针对嵌套列表增删场景的测试用例，确保依赖回调在复杂列表操作下的正确性与稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->