### PR TITLE
feat(setFieldError): simple api to update error message of single field

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ class Demo extends React.Component {
 | isFieldValidating | Check if a field is validating             | (name: [NamePath](#namepath)) => boolean                                   |
 | resetFields       | Reset fields status                        | (fields?: [NamePath](#namepath)[]) => void                                 |
 | setFields         | Set fields status                          | (fields: FieldData[]) => void                                              |
+| setFieldValue     | Set field value                            | (name: [NamePath](#namepath), value: any) => void                          |
+| setFieldError     | Set a field error list                     | (name: [NamePath](#namepath), errors: string[]) => void                    |
 | setFieldsValue    | Set fields value                           | (values) => void                                                           |
 | submit            | Trigger form submit                        | () => void                                                                 |
 | validateFields    | Trigger fields to validate                 | (nameList?: [NamePath](#namepath)[], options?: ValidateOptions) => Promise |

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -95,6 +95,7 @@ export class FormStore {
     resetFields: this.resetFields,
     setFields: this.setFields,
     setFieldValue: this.setFieldValue,
+    setFieldError: this.setFieldError,
     setFieldsValue: this.setFieldsValue,
     validateFields: this.validateFields,
     submit: this.submit,
@@ -813,6 +814,15 @@ export class FormStore {
         errors: [],
         warnings: [],
         touched: true,
+      },
+    ]);
+  };
+
+  private setFieldError = (name: NamePath, errors: string[]) => {
+    this.setFields([
+      {
+        name,
+        errors,
       },
     ]);
   };

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -823,6 +823,7 @@ export class FormStore {
       {
         name,
         errors,
+        touched: true,
       },
     ]);
   };

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -282,6 +282,7 @@ export interface FormInstance<Values = any> {
   resetFields: (fields?: NamePath<Values>[]) => void;
   setFields: (fields: FieldData<Values>[]) => void;
   setFieldValue: (name: NamePath<Values>, value: any) => void;
+  setFieldError: (name: NamePath<Values>, errors: string[]) => void;
   setFieldsValue: (values: RecursivePartial<Values>) => void;
   validateFields: ValidateFields<Values>;
 

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -913,6 +913,32 @@ describe('Form.Basic', () => {
     expect(formRef.current.isFieldTouched(['list', 2])).toBeFalsy();
   });
 
+  it('setFieldError', () => {
+    const formRef = React.createRef<FormRef>();
+
+    render(
+      <Form ref={formRef} initialValues={{ username: 'light' }}>
+        <Field name="username">
+          <Input />
+        </Field>
+      </Form>,
+    );
+
+    expect(formRef.current.getFieldError('username')).toEqual([]);
+
+    act(() => {
+      formRef.current.setFieldError('username', ['Set single error']);
+    });
+
+    expect(formRef.current.getFieldError('username')).toEqual(['Set single error']);
+
+    act(() => {
+      formRef.current.setFieldError('username', []);
+    });
+
+    expect(formRef.current.getFieldError('username')).toEqual([]);
+  });
+
   it('onMetaChange should only trigger when meta changed', () => {
     const onMetaChange = jest.fn();
     const formRef = React.createRef<FormRef>();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 在表单实例 API 中新增可直接设置单个字段错误的方法（setFieldError）。
  * 文档中新增/补充了单个字段值设置的方法说明（setFieldValue）。

* **测试**
  * 添加针对 setFieldError 的单元测试，验证错误设置与清除行为。

* **文档**
  * 已将相关方法条目加入表单实例 API 文档。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->