### PR TITLE
fix: preserve null unions in setFieldsValue types

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -245,14 +245,12 @@ export interface InternalHooks {
 
 /** Only return partial when type is not any */
 type RecursivePartial<T> =
-  NonNullable<T> extends object
-    ? {
-        [P in keyof T]?: NonNullable<T[P]> extends (infer U)[]
-          ? RecursivePartial<U>[]
-          : NonNullable<T[P]> extends object
-            ? RecursivePartial<T[P]>
-            : T[P];
-      }
+  T extends (infer U)[]
+    ? RecursivePartial<U>[]
+    : T extends object
+      ? {
+          [P in keyof T]?: RecursivePartial<T[P]>;
+        }
     : T;
 
 export type FilterFunc = (meta: Meta | null) => boolean;

--- a/tests/nameTypeCheck.test.tsx
+++ b/tests/nameTypeCheck.test.tsx
@@ -2,7 +2,7 @@
 import React, { useMemo } from 'react';
 import { render } from '@testing-library/react';
 import Form, { Field, List } from '../src';
-import type { NamePath } from '../src/interface';
+import type { FormInstance, NamePath } from '../src/interface';
 
 describe('nameTypeCheck', () => {
   it('typescript', () => {
@@ -13,9 +13,32 @@ describe('nameTypeCheck', () => {
       d?: { d1?: string[]; d2?: string };
       e?: { e1?: { e2?: string; e3?: string[]; e4: { e5: { e6: string } } } };
       list?: { age?: string }[];
+      strictList?: { age: string; name: string }[];
+      user?: { profile: { name: string; tags: string[] } };
+      nullableList?: string[] | null;
+      nullableObjectList?: { name?: string }[] | null;
     };
 
     type fieldType = NamePath<FieldType>;
+
+    type SetFieldsValueParam = Parameters<FormInstance<FieldType>['setFieldsValue']>[0];
+
+    const nullableListAsNull: SetFieldsValueParam = { nullableList: null };
+    const nullableListAsArray: SetFieldsValueParam = { nullableList: ['bamboo'] };
+    const nullableObjectListAsNull: SetFieldsValueParam = { nullableObjectList: null };
+    const nullableObjectListAsArray: SetFieldsValueParam = {
+      nullableObjectList: [{ name: 'light' }],
+    };
+    const optionalNestedObjectAsPartial: SetFieldsValueParam = {
+      user: {
+        profile: {
+          name: 'light',
+        },
+      },
+    };
+    const optionalListAsPartial: SetFieldsValueParam = {
+      strictList: [{ age: '18' }],
+    };
 
     const Demo: React.FC = () => {
       return (


### PR DESCRIPTION
## 变更说明
- 修复 `RecursivePartial` 对 `null` 联合类型的错误收窄，使 `setFieldsValue` 能正确接受 `数组 | null` 类型的字段
- 保留历史上的类型行为，确保可选父字段下的递归 partial 能力不受影响
- 补充类型回归测试，覆盖 `null` 联合场景以及之前可选嵌套字段的 partial 场景

## 验证
- `npm run lint:tsc`

- fix https://github.com/ant-design/ant-design/issues/57707
