### PR TITLE
fix: support Partial values in setFieldsValue

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -280,7 +280,7 @@ export interface FormInstance<Values = any> {
   resetFields: (fields?: NamePath<Values>[]) => void;
   setFields: (fields: FieldData<Values>[]) => void;
   setFieldValue: (name: NamePath<Values>, value: any) => void;
-  setFieldsValue: (values: RecursivePartial<Values>) => void;
+  setFieldsValue: (values: RecursivePartial<Values> | Partial<Values>) => void;
   validateFields: ValidateFields<Values>;
 
   // New API

--- a/tests/nameTypeCheck.test.tsx
+++ b/tests/nameTypeCheck.test.tsx
@@ -23,6 +23,13 @@ describe('nameTypeCheck', () => {
 
     type SetFieldsValueParam = Parameters<FormInstance<FieldType>['setFieldsValue']>[0];
 
+    const forwardGenericSetFieldsValue = <Values,>(
+      form: FormInstance<Values>,
+      values: Partial<Values>,
+    ) => {
+      form.setFieldsValue(values);
+    };
+
     const nullableListAsNull: SetFieldsValueParam = { nullableList: null };
     const nullableListAsArray: SetFieldsValueParam = { nullableList: ['bamboo'] };
     const nullableObjectListAsNull: SetFieldsValueParam = { nullableObjectList: null };


### PR DESCRIPTION
## Summary
- accept `Partial<Values>` in `setFieldsValue` alongside the existing `RecursivePartial<Values>` typing
- preserve the current recursive partial behavior for nested field updates
- add type regression coverage for generic wrappers that forward `Partial<Values>` into `setFieldsValue`

## Verification
- `npm run lint:tsc`
- `npm test -- --runInBand tests/nameTypeCheck.test.tsx`

Refs ant-design/ant-design#57723


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * 增强表单字段值设置方法的参数灵活性，现支持更多参数类型。

* **测试**
  * 新增类型检查测试用例。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->