### PR TITLE
feat: add getFieldsName API to form instance

### DIFF
--- a/docs/demo/getFieldsName.md
+++ b/docs/demo/getFieldsName.md
@@ -1,0 +1,3 @@
+## getFieldsName
+
+<code src="../examples/getFieldsName.tsx"></code>

--- a/docs/examples/getFieldsName.tsx
+++ b/docs/examples/getFieldsName.tsx
@@ -1,0 +1,25 @@
+import Form, { Field } from 'rc-field-form';
+import React from 'react';
+import Input from './components/Input';
+
+export default () => {
+  const [form] = Form.useForm();
+
+  return (
+    <Form form={form}>
+      <Field name="username">
+        <Input placeholder="Username" />
+      </Field>
+      <Field name={['profile', 'email']}>
+        <Input placeholder="profile.email" />
+      </Field>
+      <Field shouldUpdate>
+        {() => (
+          <pre style={{ marginTop: 16, fontSize: 12 }}>
+            {JSON.stringify(form.getFieldsName(), null, 2)}
+          </pre>
+        )}
+      </Field>
+    </Form>
+  );
+};

--- a/src/FieldContext.ts
+++ b/src/FieldContext.ts
@@ -14,6 +14,7 @@ const Context = React.createContext<InternalFormInstance>({
   getFieldsValue: warningFunc,
   getFieldError: warningFunc,
   getFieldWarning: warningFunc,
+  getFieldsName: warningFunc,
   getFieldsError: warningFunc,
   isFieldsTouched: warningFunc,
   isFieldTouched: warningFunc,

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -87,6 +87,7 @@ export class FormStore {
     getFieldsValue: this.getFieldsValue,
     getFieldError: this.getFieldError,
     getFieldWarning: this.getFieldWarning,
+    getFieldsName: this.getFieldsName,
     getFieldsError: this.getFieldsError,
     isFieldsTouched: this.isFieldsTouched,
     isFieldTouched: this.isFieldTouched,
@@ -343,6 +344,11 @@ export class FormStore {
     });
 
     return mergedValues;
+  };
+
+  private getFieldsName = (): InternalNamePath[] => {
+    this.warningUnhooked();
+    return this.getFieldEntities(true).map(entity => entity.getNamePath());
   };
 
   private getFieldValue = (name: NamePath) => {

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -272,6 +272,7 @@ export interface FormInstance<Values = any> {
   getFieldError: (name: NamePath<Values>) => string[];
   getFieldsError: (nameList?: NamePath<Values>[]) => FieldError[];
   getFieldWarning: (name: NamePath<Values>) => string[];
+  getFieldsName: () => NamePath<Values>[];
   isFieldsTouched: ((nameList?: NamePath<Values>[], allFieldsTouched?: boolean) => boolean) &
     ((allFieldsTouched?: boolean) => boolean);
   isFieldTouched: (name: NamePath<Values>) => boolean;

--- a/tests/getFieldsName.test.tsx
+++ b/tests/getFieldsName.test.tsx
@@ -1,0 +1,98 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import Form, { Field, List } from '../src';
+import type { FormInstance } from '../src';
+import { Input } from './common/InfoField';
+
+describe('getFieldsName', () => {
+  it('returns empty array when no named fields', () => {
+    const formRef = React.createRef<FormInstance>();
+    render(<Form ref={formRef} />);
+    expect(formRef.current!.getFieldsName()).toEqual([]);
+  });
+
+  it('returns name paths of registered fields', () => {
+    const formRef = React.createRef<FormInstance>();
+    render(
+      <Form ref={formRef}>
+        <Field name="username">
+          <Input />
+        </Field>
+        <Field name={['profile', 'email']}>
+          <Input />
+        </Field>
+      </Form>,
+    );
+    expect(formRef.current!.getFieldsName()).toEqual([['username'], ['profile', 'email']]);
+  });
+
+  it('excludes field without name', () => {
+    const formRef = React.createRef<FormInstance>();
+    render(
+      <Form ref={formRef}>
+        <Field name="a">
+          <Input />
+        </Field>
+        <Field>{() => null}</Field>
+      </Form>,
+    );
+    expect(formRef.current!.getFieldsName()).toEqual([['a']]);
+  });
+
+  it('includes one entry per Field with the same name', () => {
+    const formRef = React.createRef<FormInstance>();
+    render(
+      <Form ref={formRef}>
+        <Field name="x">
+          <Input />
+        </Field>
+        <Field name="x">
+          <Input />
+        </Field>
+      </Form>,
+    );
+    expect(formRef.current!.getFieldsName()).toEqual([['x'], ['x']]);
+  });
+
+  it('updates when field unmounts', () => {
+    const formRef = React.createRef<FormInstance>();
+    const Demo = ({ show }: { show: boolean }) => (
+      <Form ref={formRef}>
+        <Field name="keep">
+          <Input />
+        </Field>
+        {show ? (
+          <Field name="toggle">
+            <Input />
+          </Field>
+        ) : null}
+      </Form>
+    );
+    const { rerender } = render(<Demo show />);
+    expect(formRef.current!.getFieldsName()).toEqual([['keep'], ['toggle']]);
+    rerender(<Demo show={false} />);
+    expect(formRef.current!.getFieldsName()).toEqual([['keep']]);
+  });
+
+  it('includes Form.List item fields', () => {
+    const formRef = React.createRef<FormInstance>();
+    render(
+      <Form ref={formRef} initialValues={{ list: ['a', 'b'] }}>
+        <List name="list">
+          {fields =>
+            fields.map(f => (
+              <Field {...f} key={f.key}>
+                <Input />
+              </Field>
+            ))
+          }
+        </List>
+      </Form>,
+    );
+    expect(formRef.current!.getFieldsName()).toEqual([
+      ['list', 0],
+      ['list', 1],
+      ['list'],
+    ]);
+  });
+});


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 🆕 新特性提交
- [ ] 🐞 Bug 修复
- [ ] 📝 站点、文档改进
- [ ] 📽️ 演示代码改进
- [ ] 💄 组件样式/交互改进
- [ ] 🤖 TypeScript 定义更新
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化改进
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流程
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他改动（是关于什么的改动？）

### 🔗 相关 Issue
issues: [57757](https://github.com/ant-design/ant-design/issues/57757)

### 💡 需求背景和解决方案
新增 getFieldsName api 获取 Form.Item的name属性值

### 📝 更新日志

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Form Add getFieldsName method to get all field names |
| 🇨🇳 中文 | Form 新增 getFieldsName 方法，用于获取表单所有字段名 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增 `getFieldsName()` 方法，支持获取表单中所有已注册字段的名称路径，包括嵌套字段和列表字段。

* **文档**
  * 添加 getFieldsName 功能文档和实际使用示例代码。

* **测试**
  * 新增全面的测试套件，覆盖多个使用场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->