### PR TITLE
chore(deps): upgrade async-validator to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-dom": ">=16.9.0"
   },
   "dependencies": {
-    "@rc-component/async-validator": "^5.1.0",
+    "@rc-component/async-validator": "^6.0.0",
     "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"
   },


### PR DESCRIPTION
Upgrade @rc-component/async-validator from ^5.1.0 to ^6.0.0.

This keeps @rc-component/form on the v6 async-validator line while retaining the existing tel validation support introduced in async-validator 5.1.0.

Validation:
- ut update
- ut test
- ut run lint:tsc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **Chores**
  * 更新了表单验证相关依赖库至新的主版本，确保持续获得最新的功能和安全更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->