### PR TITLE
fix(type): accept partial generic form values

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -244,13 +244,15 @@ export interface InternalHooks {
 }
 
 /** Only return partial when type is not any */
-type RecursivePartial<T> = T extends Date | RegExp | Function | Map<any, any> | Set<any>
+export type RecursivePartial<T> = T extends Date | RegExp | Function | Map<any, any> | Set<any>
   ? T
   : T extends (infer U)[]
     ? RecursivePartial<U>[]
-    : T extends object
-      ? { [P in keyof T]?: RecursivePartial<T[P]> }
-      : T;
+    : T extends readonly (infer U)[]
+      ? readonly RecursivePartial<U>[]
+      : T extends object
+        ? { [P in keyof T]?: RecursivePartial<T[P]> }
+        : T;
 
 export type FilterFunc = (meta: Meta | null) => boolean;
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -244,14 +244,13 @@ export interface InternalHooks {
 }
 
 /** Only return partial when type is not any */
-type RecursivePartial<T> =
-  T extends (infer U)[]
+type RecursivePartial<T> = T extends Date | RegExp | Function | Map<any, any> | Set<any>
+  ? T
+  : T extends (infer U)[]
     ? RecursivePartial<U>[]
     : T extends object
-      ? {
-          [P in keyof T]?: RecursivePartial<T[P]>;
-        }
-    : T;
+      ? { [P in keyof T]?: RecursivePartial<T[P]> }
+      : T;
 
 export type FilterFunc = (meta: Meta | null) => boolean;
 
@@ -280,7 +279,7 @@ export interface FormInstance<Values = any> {
   resetFields: (fields?: NamePath<Values>[]) => void;
   setFields: (fields: FieldData<Values>[]) => void;
   setFieldValue: (name: NamePath<Values>, value: any) => void;
-  setFieldsValue: (values: RecursivePartial<Values>) => void;
+  setFieldsValue: (values: RecursivePartial<Values> | Partial<Values>) => void;
   validateFields: ValidateFields<Values>;
 
   // New API

--- a/src/utils/validateUtil.ts
+++ b/src/utils/validateUtil.ts
@@ -76,7 +76,7 @@ async function validateRule(
 
   try {
     await Promise.resolve(validator.validate({ [name]: value }, { ...options }));
-  } catch (errObj) {
+  } catch (errObj: any) {
     if (errObj.errors) {
       result = errObj.errors.map(({ message }, index: number) => {
         const mergedMessage = message === CODE_LOGIC_ERROR ? messages.default : message;

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -754,7 +754,7 @@ describe('Form.Basic', () => {
     );
     expect(() => {
       fireEvent.change(container.querySelector('input'), { target: { value: 'Light' } });
-    }).not.toThrowError();
+    }).not.toThrow();
   });
 
   it('setFieldsValue for List should work', () => {
@@ -835,7 +835,7 @@ describe('Form.Basic', () => {
 
   // https://github.com/ant-design/ant-design/issues/34768
   it('remount should not clear current value', () => {
-    let refForm: FormInstance = null;
+    let refForm: FormInstance | null = null;
 
     const Demo: React.FC<any> = ({ remount }) => {
       const [form] = Form.useForm();
@@ -857,7 +857,7 @@ describe('Form.Basic', () => {
 
     const { container, rerender } = render(<Demo />);
     act(() => {
-      refForm.setFieldsValue({ name: 'bamboo' });
+      refForm?.setFieldsValue({ name: 'bamboo' });
     });
     expect(container.querySelector<HTMLInputElement>('input').value).toBe('bamboo');
     rerender(<Demo remount />);
@@ -1042,5 +1042,13 @@ describe('Form.Basic', () => {
       await Promise.resolve();
     });
     expect(formRef.current?.getFieldError('light')).toHaveLength(0);
+  });
+
+  it('accepts partial values from generic helper', () => {
+    const useGenericSetter = <Values,>() => {
+      const [form] = Form.useForm<Values>();
+      return (values: Partial<Values>) => form.setFieldsValue(values);
+    };
+    expect(useGenericSetter).toBeInstanceOf(Function);
   });
 });

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1044,11 +1044,4 @@ describe('Form.Basic', () => {
     expect(formRef.current?.getFieldError('light')).toHaveLength(0);
   });
 
-  it('accepts partial values from generic helper', () => {
-    const useGenericSetter = <Values,>() => {
-      const [form] = Form.useForm<Values>();
-      return (values: Partial<Values>) => form.setFieldsValue(values);
-    };
-    expect(useGenericSetter).toBeInstanceOf(Function);
-  });
 });

--- a/tests/nameTypeCheck.test.tsx
+++ b/tests/nameTypeCheck.test.tsx
@@ -39,6 +39,10 @@ describe('nameTypeCheck', () => {
     const optionalListAsPartial: SetFieldsValueParam = {
       strictList: [{ age: '18' }],
     };
+    const useGenericSetter = <Values,>() => {
+      const [form] = Form.useForm<Values>();
+      return (values: Partial<Values>) => form.setFieldsValue(values);
+    };
 
     const Demo: React.FC = () => {
       return (


### PR DESCRIPTION
- fix https://github.com/ant-design/ant-design/issues/57723

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Refactor**
  * 优化通用类型 `RecursivePartial`：对 `Date/RegExp/Function/Map/Set` 保持原类型，不再递归展开；其余对象/数组仍继续递归 partial 化。
  * 扩展表单方法 `setFieldsValue` 签名：支持同时接收递归 Partial 与浅层 `Partial`。

* **Tests**
  * 调整断言与表单引用处理方式，并新增类型相关辅助用例，覆盖浅层 Partial 传入与断言。

* **Chores**
  * 强化校验异常的类型标注以满足 TypeScript 约束。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->