### PR TITLE
fix(type): restrict useWatch typed paths

### DIFF
--- a/docs/examples/useWatch.tsx
+++ b/docs/examples/useWatch.tsx
@@ -47,10 +47,8 @@ export default () => {
   const demo2 = Form.useWatch(['demo1', 'demo2'], form);
   const demo3 = Form.useWatch(['demo1', 'demo2', 'demo3'], form);
   const demo4 = Form.useWatch(['demo1', 'demo2', 'demo3', 'demo4'], form);
-  const demo5 = Form.useWatch(['demo1', 'demo2', 'demo3', 'demo4', 'demo5'], form);
-  const more = Form.useWatch(['age', 'name', 'gender'], form);
   const hidden = Form.useWatch(['hidden'], { form, preserve: true });
-  console.log('main watch', values, demo1, demo2, main, age, demo3, demo4, demo5, more, hidden);
+  console.log('main watch', values, demo1, demo2, main, age, demo3, demo4, hidden);
   return (
     <>
       <Form

--- a/src/hooks/useWatch.ts
+++ b/src/hooks/useWatch.ts
@@ -13,6 +13,9 @@ import { getNamePath, getValue } from '../utils/valueUtil';
 
 type ReturnPromise<T> = T extends Promise<infer ValueType> ? ValueType : never;
 type GetGeneric<TForm extends FormInstance> = ReturnPromise<ReturnType<TForm['validateFields']>>;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type AnyNamePath<TForm extends FormInstance> =
+  IsAny<GetGeneric<TForm>> extends true ? NamePath : never;
 
 export function stringify(value: any) {
   try {
@@ -75,13 +78,13 @@ function useWatch<ValueType = Store, TSelected = unknown>(
 // ------- selector type end -------
 
 function useWatch<TForm extends FormInstance>(
-  dependencies: NamePath,
+  dependencies: AnyNamePath<TForm>,
   form?: TForm | WatchOptions<TForm>,
 ): any;
 
-function useWatch<ValueType = Store>(
-  dependencies: NamePath,
-  form?: FormInstance | WatchOptions<FormInstance>,
+function useWatch<ValueType = Store, TForm extends FormInstance = FormInstance>(
+  dependencies: AnyNamePath<TForm>,
+  form?: TForm | WatchOptions<TForm>,
 ): ValueType;
 
 function useWatch(

--- a/src/hooks/useWatch.ts
+++ b/src/hooks/useWatch.ts
@@ -14,8 +14,16 @@ import { getNamePath, getValue } from '../utils/valueUtil';
 type ReturnPromise<T> = T extends Promise<infer ValueType> ? ValueType : never;
 type GetGeneric<TForm extends FormInstance> = ReturnPromise<ReturnType<TForm['validateFields']>>;
 type IsAny<T> = 0 extends 1 & T ? true : false;
-type AnyNamePath<TForm extends FormInstance> =
-  IsAny<GetGeneric<TForm>> extends true ? NamePath : never;
+type IsEqual<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+type AnyNamePath<TForm extends FormInstance, ValueType = Store> =
+  IsAny<GetGeneric<TForm>> extends true
+    ? NamePath
+    : IsAny<ValueType> extends true
+      ? NamePath
+      : IsEqual<ValueType, Store> extends true
+        ? NamePath<GetGeneric<TForm>>
+        : NamePath;
 
 export function stringify(value: any) {
   try {
@@ -24,6 +32,18 @@ export function stringify(value: any) {
     return Math.random();
   }
 }
+
+function useWatch<
+  TDependencies1 extends keyof GetGeneric<TForm>,
+  TForm extends FormInstance,
+  TDependencies2 extends keyof GetGeneric<TForm>[TDependencies1],
+  TDependencies3 extends keyof GetGeneric<TForm>[TDependencies1][TDependencies2],
+  TDependencies4 extends keyof GetGeneric<TForm>[TDependencies1][TDependencies2][TDependencies3],
+  TDependencies5 extends keyof GetGeneric<TForm>[TDependencies1][TDependencies2][TDependencies3][TDependencies4],
+>(
+  dependencies: [TDependencies1, TDependencies2, TDependencies3, TDependencies4, TDependencies5],
+  form?: TForm | WatchOptions<TForm>,
+): GetGeneric<TForm>[TDependencies1][TDependencies2][TDependencies3][TDependencies4][TDependencies5];
 
 function useWatch<
   TDependencies1 extends keyof GetGeneric<TForm>,
@@ -83,7 +103,7 @@ function useWatch<TForm extends FormInstance>(
 ): any;
 
 function useWatch<ValueType = Store, TForm extends FormInstance = FormInstance>(
-  dependencies: AnyNamePath<TForm>,
+  dependencies: AnyNamePath<TForm, ValueType>,
   form?: TForm | WatchOptions<TForm>,
 ): ValueType;
 

--- a/tests/useWatch.test.tsx
+++ b/tests/useWatch.test.tsx
@@ -281,6 +281,7 @@ describe('useWatch', () => {
       id?: number;
       value3: string;
       path1?: { path2?: number };
+      deep?: { path1?: { path2?: { path3?: { path4?: string } } } };
       demo1?: { demo2?: { demo3?: { demo4?: string } } };
     };
 
@@ -295,12 +296,16 @@ describe('useWatch', () => {
       const demo4 = Form.useWatch(['demo1', 'demo2', 'demo3', 'demo4'], form);
       const value3 = Form.useWatch('value3', form);
       const pathValue = Form.useWatch(['path1', 'path2'], form);
+      const deepValue = Form.useWatch(['deep', 'path1', 'path2', 'path3', 'path4'], form);
+      const dynamicValue = Form.useWatch<string>(['dynamic', 'path'], form);
       const demo = Form.useWatch<string>(['demo']);
       const typeCheck: [
         Expect<Equal<IsAny<typeof value3>, false>>,
         Expect<Equal<typeof value3, string>>,
         Expect<Equal<typeof pathValue, number | undefined>>,
-      ] = [true, true, true];
+        Expect<Equal<typeof deepValue, string | undefined>>,
+        Expect<Equal<typeof dynamicValue, string>>,
+      ] = [true, true, true, true, true];
 
       // @ts-expect-error not a field of FieldType
       Form.useWatch('unknown', form);
@@ -328,6 +333,8 @@ describe('useWatch', () => {
             demo4,
             value3,
             pathValue,
+            deepValue,
+            dynamicValue,
             demo,
             typeCheck,
             values2,

--- a/tests/useWatch.test.tsx
+++ b/tests/useWatch.test.tsx
@@ -8,6 +8,11 @@ import { Input } from './common/InfoField';
 import { stringify } from '../src/hooks/useWatch';
 import { changeValue } from './common';
 
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type Equal<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
 describe('useWatch', () => {
   beforeEach(() => {
     jest.useFakeTimers();
@@ -274,6 +279,8 @@ describe('useWatch', () => {
       demo?: string;
       demo2?: string;
       id?: number;
+      value3: string;
+      path1?: { path2?: number };
       demo1?: { demo2?: { demo3?: { demo4?: string } } };
     };
 
@@ -286,9 +293,19 @@ describe('useWatch', () => {
       const demo2 = Form.useWatch(['demo1', 'demo2'], form);
       const demo3 = Form.useWatch(['demo1', 'demo2', 'demo3'], form);
       const demo4 = Form.useWatch(['demo1', 'demo2', 'demo3', 'demo4'], form);
-      const demo5 = Form.useWatch(['demo1', 'demo2', 'demo3', 'demo4', 'demo5'], form);
-      const more = Form.useWatch(['age', 'name', 'gender'], form);
+      const value3 = Form.useWatch('value3', form);
+      const pathValue = Form.useWatch(['path1', 'path2'], form);
       const demo = Form.useWatch<string>(['demo']);
+      const typeCheck: [
+        Expect<Equal<IsAny<typeof value3>, false>>,
+        Expect<Equal<typeof value3, string>>,
+        Expect<Equal<typeof pathValue, number | undefined>>,
+      ] = [true, true, true];
+
+      // @ts-expect-error not a field of FieldType
+      Form.useWatch('unknown', form);
+      // @ts-expect-error not a nested field of FieldType
+      Form.useWatch(['path1', 'unknown'], form);
 
       const values2 = Form.useWatch(
         _values => ({ newName: _values.name, newAge: _values.age }),
@@ -309,9 +326,10 @@ describe('useWatch', () => {
             demo2,
             demo3,
             demo4,
-            demo5,
-            more,
+            value3,
+            pathValue,
             demo,
+            typeCheck,
             values2,
             values3,
           })}


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

Related to ant-design/ant-design#58405.
close https://github.com/ant-design/ant-design/issues/58405

### 💡 Background and Solution

`Form.useWatch` can infer watched value types from typed form instances, but the broad `NamePath` fallback overload also accepts unknown field paths when a typed form is provided. As a result, invalid field names can pass TypeScript checks.

This change keeps the runtime behavior unchanged and preserves the existing loose behavior for untyped forms. For typed form instances, the broad fallback overload is now limited to forms whose value type is `any`, so valid field paths continue to infer their value types while unknown top-level or nested paths are rejected by TypeScript.

The type coverage now verifies that:

- a typed scalar field returns its declared value type;
- a nested optional path preserves `undefined` in the return type;
- unknown typed paths fail type checking.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improve `Form.useWatch` type checking for typed forms to reject unknown field paths. |
| 🇨🇳 Chinese | 改进 `Form.useWatch` 在类型化表单中的类型检查，未知字段路径将被拒绝。 |

### ✅ Test Plan

- `npm run lint:tsc`
- `npm test -- tests/useWatch.test.tsx --runInBand`
- `npm run lint`
- `npm test -- --runInBand`
- `npm run compile`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **功能改进**
  * 优化 `useWatch` 的类型推导与依赖项签名支持，增强 TypeScript 校验的准确性与智能补全体验。

* **测试**
  * 扩展 `useWatch` 的编译期类型校验用例，新增字段/路径覆盖，并补充错误场景断言。

* **文档**
  * 更新示例中的 `useWatch` 订阅与输出内容，移除多余监听项并简化日志结果。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->